### PR TITLE
upgrade deps to work with latest chai version

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "bit-mask": "0.0.2-alpha"
   },
   "devDependencies": {
-    "chai": "^1.9.1",
+    "chai": "latest",
     "chai-json-schema": "1.0.4",
     "grunt": "0.4.1",
     "grunt-bump": "0.0.11",
@@ -55,6 +55,6 @@
     "underscore": "1.6.0"
   },
   "peerDependencies": {
-    "chai": ">= 1.6.1 < 2"
+    "chai": ">= 1.6.1 < 3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -55,6 +55,6 @@
     "underscore": "1.6.0"
   },
   "peerDependencies": {
-    "chai": ">= 1.6.1 < 3"
+    "chai": ">= 1.6.1 < 4"
   }
 }


### PR DESCRIPTION
Just ran the tests and everything is still looking good :+1: 

I updated the chai dev dependency to "latest", as there's no way for this to break production code, it will just fail your tests as soon as there is a breaking change pushed, which is more or less always helpful, since this is something you definitely need to know.