### PR TITLE
Added equality and deep-equality checks for files

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,10 @@ Assert the return value of `path.basename(path)`
 
 	expect(path).to.have.basename(name, ?msg);
 	expect(path).to.not.have.basename(name, ?msg);
-	
+
 	path.should.have.basename(name, ?msg);
 	path.should.not.have.basename(name, ?msg);
-	
+
 	assert.basename(path, name, ?msg);
 	assert.notBasename(path, name, ?msg);
 
@@ -45,10 +45,10 @@ Assert the return value of `path.dirname(path)`
 
 	expect(path).to.have.dirname(name, ?msg);
 	expect(path).to.not.have.dirname(name, ?msg);
-	
+
 	path.should.have.dirname(name, ?msg);
 	path.should.not.have.dirname(name, ?msg);
-	
+
 	assert.dirname(path, name, ?msg);
 	assert.notDirname(path, name, ?msg);
 
@@ -59,10 +59,10 @@ Assert the return value of `path.extname(path)`
 
 	expect(path).to.have.extname(name, ?msg);
 	expect(path).to.not.have.extname(name, ?msg);
-	
+
 	path.should.have.extname(name, ?msg);
 	path.should.not.have.extname(name, ?msg);
-	
+
 	assert.extname(path, name, ?msg);
 	assert.notExtname(path, name, ?msg);
 
@@ -75,10 +75,10 @@ Uses `fs.existsSync()`.
 
 	expect(path).to.be.a.path(?msg);
 	expect(path).to.not.be.a.path(?msg);
-	
+
 	path.should.be.a.path(?msg);
 	path.should.not.be.a.path(?msg);
-	
+
 	assert.pathExists(path, ?msg);
 	assert.notPathExists(path, ?msg);
 
@@ -88,28 +88,28 @@ Use of Chai's `exist`-chain would've been nice *but* has issues with negations a
 ### directory()
 
 Assert the path exists and is a directory.
-	
+
 Uses `fs.statSync().isDirectory()`
 
 	expect(path).to.be.a.directory(?msg);
 	expect(path).to.not.be.a.directory(?msg);
-	
+
 	path.should.be.a.directory(?msg);
 	path.should.not.be.a.directory(?msg);
-	
+
 	assert.isDirectory(path,  ?msg);
 	assert.notIsDirectory(path, ?msg);
 
 ### directory().and.empty
 
-Assert the path exists, is a directory and contains zero item. 
+Assert the path exists, is a directory and contains zero item.
 
 	expect(path).to.be.a.directory(?msg).and.empty;
 	expect(path).to.be.a.directory(?msg).and.not.empty;
-	
+
 	path.should.be.a.directory(?msg).and.empty;
 	path.should.be.a.directory(?msg).and.not.empty;
-	
+
 	assert.isEmptyDirectory(path, ?msg);
 	assert.notIsEmptyDirectory(path, ?msg);
 
@@ -125,42 +125,115 @@ Uses `fs.statSync().isFile()`
 
 	expect(path).to.be.a.file(?msg);
 	expect(path).to.not.be.a.file(?msg);
-	
+
 	path.should.be.a.file(?msg);
 	path.should.not.be.a.file(?msg);
-	
+
 	assert.isFile(path, ?msg);
 	assert.notIsFile(path, ?msg);
 
 ### file().and.empty
 
-Assert the path exists, is a file and has zero size. 
+Assert the path exists, is a file and has zero size.
 
 	expect(path).to.be.a.file(?msg).and.empty;
 	expect(path).to.be.a.file(?msg).and.not.empty;
-	
+
 	path.should.be.a.file(?msg).and.empty;
 	path.should.be.a.file(?msg).and.not.empty;
-	
+
 	assert.isEmptyFile(path, ?msg);
-	assert.notIsEmptyFile(path, ?msg); 
+	assert.notIsEmptyFile(path, ?msg);
 
 * Chains after `file()`
 * Uses `fs.statSync().size === 0`.
 * To negate this using `expect/should` you chain the `.not`-negation ***after*** the regular `file()`.
 
+### file().and.equal(otherPath)
+
+Assert the _both_ paths exist, are files and contain the same content
+
+	expect(path).to.be.a.file(?msg).and.equal(otherPath, ?msg);
+	expect(path).to.be.a.file(?msg).and.not.equal(otherPath, ?msg);
+
+	path.should.be.a.file(?msg).and.equal(otherPath, ?msg);
+	path.should.be.a.file(?msg).and.not.equal(otherPath, ?msg);
+
+	assert.fileEqual(path, otherPath, ?msg);
+	assert.notFileEqual(path, otherPath, ?msg);
+
+* Reads both files as utf8 text (could update to support base64, binary Buffer etc).
+* To negate this using `expect/should` you chain the `.not`-negation ***after*** the regular `file()`.
+
+### file().and.deep.equal(otherPath)
+
+Assert the _both_ paths exist, are files, contain the same content, and have the same attributes, including:
+
+ * owner (`stats.uid`)
+ * group (`stats.gid`)
+ * creation time (`stats.birthtime`)
+ * last-modified time (`stats.mtime`)
+ * last-changed time (`stats.ctime`)
+ * last-access time (`stats.atime`)
+
+```
+	expect(path).to.be.a.file(?msg).and.deep.equal(otherPath, ?msg);
+	expect(path).to.be.a.file(?msg).and.not.deep.equal(otherPath, ?msg);
+
+	path.should.be.a.file(?msg).and.deep.equal(otherPath, ?msg);
+	path.should.be.a.file(?msg).and.not.deep.equal(otherPath, ?msg);
+
+	assert.fileDeepEqual(path, otherPath, ?msg);
+	assert.notFileDeepEqual(path, otherPath, ?msg);
+```
+
+* Reads both files as utf8 text (could update to support base64, binary Buffer etc).
+* To negate this using `expect/should` you chain the `.not`-negation ***after*** the regular `file()`.
+
+### content()
+
+Assert the path exists, is a file and has specific content.
+
+	expect(path).to.have.content(data, ?msg);
+	expect(path).to.not.have.content(data, ?msg);
+
+	path.should.have.content(data, ?msg);
+	path.should.not.have.content(data, ?msg);
+
+	assert.fileContent(path, data, ?msg);
+	assert.notFileContent(path, data, ?msg);
+
+* Reads file as utf8 text (could update to support base64, binary Buffer etc).
+
+Note: *In a future version this might be supported as a chain behind file() and directory()*
+
+### content.that.match(/xyz/)
+
+Assert the path exists, is a file and has content that match the regular expression.
+
+	expect(path).to.have.content.that.match(/xyz/, ?msg);
+	expect(path).to.not.have.content.that.match(/xyz/, ?msg);
+
+	path.should.have.content.that.match(/xyz/, ?msg);
+	path.should.not.have.content.that.match(/xyz/, ?msg);
+
+	assert.fileContentMatch(path, /xyz/, ?msg);
+	assert.notFileContentMatch(path, /xyz/, ?msg);
+
+* Reads file as utf8 text (could update to support base64, binary Buffer etc).
+
 ### file().with.json
 
-Assert the path exists, is a file and contains json parsable text. 
+Assert the path exists, is a file and contains json parsable text.
 
 	expect(path).to.be.a.file(?msg).with.json;
 	expect(path).to.be.a.file(?msg).with.not.json;
-	
+
 	path.should.be.a.file(?msg).with.json;
 	path.should.be.a.file(?msg).with.not.json;
-	
+
 	assert.jsonFile(path, ?msg);
-	assert.notJsonFile(path, ?msg); 
+	assert.notJsonFile(path, ?msg);
 
 * Chains after `file()`
 * To negate this using `expect/should` you chain the `.not`-negation ***after*** the regular `file()`.
@@ -172,50 +245,18 @@ Assert the path exists, is a file, contains json parsable text conforming to giv
 
 	expect(path).to.be.a.file(?msg).with.json.using.schema(obj);
 	expect(path).to.be.a.file(?msg).with.json.not.using.schema(obj);
-	
+
 	path.should.be.a.file(?msg).with.json.using.schema(obj);
 	path.should.be.a.file(?msg).with.json.not.using.schema(obj);
-	
+
 	assert.jsonSchemaFile(path, schema,?msg);
-	assert.notJsonSchemaFile(path, schema, ?msg); 
+	assert.notJsonSchemaFile(path, schema, ?msg);
 
 * Chains after `file().with.json`
-* The schema parameter must be a valid JSON-Schema v4. 
+* The schema parameter must be a valid JSON-Schema v4.
 * Depends on the [chai-json-schema](https://github.com/Bartvds/chai-json-schema) plugin to be separately activated with `chai.use()`.
 * To negate this using `expect/should` you chain the `.not`-negation ***after*** the regular `json`.
 * The `with` and `using` chains are just syntax sugar.
-
-### content()
-
-Assert the path exists, is a file and has specific content.
-
-	expect(path).to.have.content(data, ?msg);
-	expect(path).to.not.have.content(data, ?msg);
-	
-	path.should.have.content(data, ?msg);
-	path.should.not.have.content(data, ?msg);
-	
-	assert.fileContent(path, data, ?msg);
-	assert.notFileContent(path, data, ?msg);
-
-* Reads file as utf8 text (could update to support base64, binary Buffer etc). 
-
-Note: *In a future version this might be supported as a chain behind file() and directory()* 
-
-### content.that.match(/xyz/)
-
-Assert the path exists, is a file and has content that match the regular expression. 
-
-	expect(path).to.have.content.that.match(/xyz/, ?msg);
-	expect(path).to.not.have.content.that.match(/xyz/, ?msg);
-	
-	path.should.have.content.that.match(/xyz/, ?msg);
-	path.should.not.have.content.that.match(/xyz/, ?msg);
-	
-	assert.fileContentMatch(path, /xyz/, ?msg);
-	assert.notFileContentMatch(path, /xyz/, ?msg);
-
-* Reads file as utf8 text.
 
 ###  Planned assertions
 
@@ -249,17 +290,17 @@ See the `Gruntfile` for additional commands.
 
 ### :wrench: Test generator
 
-This plugin uses a prototype of an "assertion plugin test generator" to generates tests for all aspects of the assertions while keeping the specs DRY. 
+This plugin uses a prototype of an "assertion plugin test generator" to generates tests for all aspects of the assertions while keeping the specs DRY.
 
 The pattern splits the test into a style declaration tree and a set of variation on 3 types of test scenarios. The generator then combines ('multiplies') every scenario variation with the style tree data to get good coverage of all cases.
 
 The style tree defines ways to use an assertion: first level is the style: expect/should and assert. Then it defines both the normal use and the negation, then divides those into different invocations patterns for each style. So you can test with/without message, or as a chained method or property etc.
 
-The tests are ways to specify assertions and the test expectations. 
+The tests are ways to specify assertions and the test expectations.
 
 * `valid`  - test expected to pass (but fail the negation)
-* `invalid` - test expected to fail (but pass the negation). 
-* `error` - test expected to always fail (even when negated), because the data is invalid (eg: bad data type, missing parameters etc). 
+* `invalid` - test expected to fail (but pass the negation).
+* `error` - test expected to always fail (even when negated), because the data is invalid (eg: bad data type, missing parameters etc).
 
 The report field is used the verify the error message if the test fails. It supports a simple template format using the assertion data object.
 

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ Assert the path exists, is a file and has zero size.
 
 ### file().and.equal(otherPath)
 
-Assert the _both_ paths exist, are files and contain the same content
+Assert that _both_ paths exist, are files and contain the same content
 
 	expect(path).to.be.a.file(?msg).and.equal(otherPath, ?msg);
 	expect(path).to.be.a.file(?msg).and.not.equal(otherPath, ?msg);
@@ -167,7 +167,7 @@ Assert the _both_ paths exist, are files and contain the same content
 
 ### file().and.deep.equal(otherPath)
 
-Assert the _both_ paths exist, are files, contain the same content, and have the same attributes, including:
+Assert that _both_ paths exist, are files, contain the same content, and have the same attributes, including:
 
  * owner (`stats.uid`)
  * group (`stats.gid`)
@@ -189,38 +189,6 @@ Assert the _both_ paths exist, are files, contain the same content, and have the
 
 * Reads both files as utf8 text (could update to support base64, binary Buffer etc).
 * To negate this using `expect/should` you chain the `.not`-negation ***after*** the regular `file()`.
-
-### content()
-
-Assert the path exists, is a file and has specific content.
-
-	expect(path).to.have.content(data, ?msg);
-	expect(path).to.not.have.content(data, ?msg);
-
-	path.should.have.content(data, ?msg);
-	path.should.not.have.content(data, ?msg);
-
-	assert.fileContent(path, data, ?msg);
-	assert.notFileContent(path, data, ?msg);
-
-* Reads file as utf8 text (could update to support base64, binary Buffer etc).
-
-Note: *In a future version this might be supported as a chain behind file() and directory()*
-
-### content.that.match(/xyz/)
-
-Assert the path exists, is a file and has content that match the regular expression.
-
-	expect(path).to.have.content.that.match(/xyz/, ?msg);
-	expect(path).to.not.have.content.that.match(/xyz/, ?msg);
-
-	path.should.have.content.that.match(/xyz/, ?msg);
-	path.should.not.have.content.that.match(/xyz/, ?msg);
-
-	assert.fileContentMatch(path, /xyz/, ?msg);
-	assert.notFileContentMatch(path, /xyz/, ?msg);
-
-* Reads file as utf8 text (could update to support base64, binary Buffer etc).
 
 ### file().with.json
 
@@ -257,6 +225,38 @@ Assert the path exists, is a file, contains json parsable text conforming to giv
 * Depends on the [chai-json-schema](https://github.com/Bartvds/chai-json-schema) plugin to be separately activated with `chai.use()`.
 * To negate this using `expect/should` you chain the `.not`-negation ***after*** the regular `json`.
 * The `with` and `using` chains are just syntax sugar.
+
+### content()
+
+Assert the path exists, is a file and has specific content.
+
+	expect(path).to.have.content(data, ?msg);
+	expect(path).to.not.have.content(data, ?msg);
+
+	path.should.have.content(data, ?msg);
+	path.should.not.have.content(data, ?msg);
+
+	assert.fileContent(path, data, ?msg);
+	assert.notFileContent(path, data, ?msg);
+
+* Reads file as utf8 text (could update to support base64, binary Buffer etc).
+
+Note: *In a future version this might be supported as a chain behind file() and directory()*
+
+### content.that.match(/xyz/)
+
+Assert the path exists, is a file and has contents that match the regular expression.
+
+	expect(path).to.have.content.that.match(/xyz/, ?msg);
+	expect(path).to.not.have.content.that.match(/xyz/, ?msg);
+
+	path.should.have.content.that.match(/xyz/, ?msg);
+	path.should.not.have.content.that.match(/xyz/, ?msg);
+
+	assert.fileContentMatch(path, /xyz/, ?msg);
+	assert.notFileContentMatch(path, /xyz/, ?msg);
+
+* Reads file as utf8 text (could update to support base64, binary Buffer etc).
 
 ###  Planned assertions
 

--- a/docs/planned.md
+++ b/docs/planned.md
@@ -5,10 +5,6 @@ Some ideas for new assertions. I' might add these in batches when I got a use ca
 :warning: *This is not final in any way!*
 
 ````
-// content by path
-expect(path).to.be.a.file(msg).and.equal(otherPath);
-expect(path).to.be.a.file(msg).and.deep.equal(otherPath); // + mtime, uid, gid
-
 // content types
 expect(path).to.be.a.file(msg).with.xml;
 

--- a/lib/assertions/file_equal.js
+++ b/lib/assertions/file_equal.js
@@ -46,7 +46,7 @@ module.exports = function (chai, utils) {
 					var comparisons = [
 						{prop: 'uid', name: 'owner'},
 						{prop: 'gid', name: 'group id'},
-						{prop: 'atime', name: 'last-access date/time'},
+						{prop: 'atime', name: 'last-access time'},
 						{prop: 'mtime', name: 'last-modified time'},
 						{prop: 'ctime', name: 'last-changed time'},
 						{prop: 'birthtime', name: 'creation time'},

--- a/lib/assertions/file_equal.js
+++ b/lib/assertions/file_equal.js
@@ -1,0 +1,103 @@
+module.exports = function (chai, utils) {
+
+	var Assertion = chai.Assertion;
+	var flag = utils.flag;
+	var assert = chai.assert;
+
+	var fs = require('fs');
+	var format = require('util').format;
+
+	//-------------------------------------------------------------------------------------------------------------
+
+	//TODO add (utf8, base64, etc) flag chain props
+	//TODO add Buffer compare/diff
+
+
+	Assertion.overwriteMethod('equal', function (_super) {
+		return function assertContent (expected, msg) {
+			if (flag(this, 'fs.isFile')) {
+				var negated = !!flag(this, 'negate');
+				var deep = flag(this, 'deep') ? 'deep ' : '';
+
+				var obj = this._obj;
+				var preMsg = '';
+				if (msg) {
+					flag(this, 'message', msg);
+					preMsg = msg + ': ';
+				}
+
+				new chai.Assertion(expected, preMsg + 'expected-value').is.a('string');
+				new chai.Assertion(expected, preMsg + 'expected-value').to.be.a.path();
+				new chai.Assertion(expected, preMsg + 'expected-value').to.be.a.file();
+
+				var actualContent = fs.readFileSync(obj, 'utf8');
+				var expectedContent = fs.readFileSync(expected, 'utf8');
+
+				var pass = actualContent === expectedContent;
+				var expectedValue = expectedContent;
+				var actualValue = actualContent;
+				var details = '';
+
+				if (deep) {
+					//TODO move these to their own assertions (e.g. `mtime()`, `uid()`, etc.)
+					var actualStats = fs.statSync(obj);
+					var expectedStats = fs.statSync(expected);
+
+					var comparisons = [
+						{prop: 'uid', name: 'owner'},
+						{prop: 'gid', name: 'group id'},
+						{prop: 'atime', name: 'last-access date/time'},
+						{prop: 'mtime', name: 'last-modified time'},
+						{prop: 'ctime', name: 'last-changed time'},
+						{prop: 'birthtime', name: 'creation time'},
+					];
+
+					comparisons.some(function(comparison) {
+						var prop = comparison.prop;
+						var actualStat = actualStats[prop] && actualStats[prop].valueOf();
+						var expectedStat = expectedStats[prop] && expectedStats[prop].valueOf();
+						var statsMatch = actualStat === expectedStat;
+						pass = pass && statsMatch;
+
+						if (!statsMatch && !negated) {
+							// We're doing a deep-equality check, and the file contents are the same,
+							// but one of the stats is different. So, adjust the error message to be
+							// more informative & useful.
+							details = format(' (%ss are different)', comparison.name);
+							expectedValue = expectedStats[prop];
+							actualValue = actualStats[prop];
+							return true;
+						}
+					});
+				}
+
+				this.assert(
+					pass
+					, format('expected #{this} to %sequal %s%s', deep, expected, details)
+					, format('expected #{this} not to %sequal %s%s', deep, expected, details)
+					, expectedValue
+					, actualValue
+					, true 	// show diff
+				);
+			} else {
+				_super.apply(this, arguments);
+			}
+		};
+	});
+
+	assert.fileEqual = function (val, exp, msg) {
+		new chai.Assertion(val).to.be.a.file(msg).and.equal(exp, msg);
+	};
+
+	assert.notFileEqual = function (val, exp, msg) {
+		new chai.Assertion(val).to.be.a.file(msg).and.not.equal(exp, msg);
+	};
+
+	assert.fileDeepEqual = function (val, exp, msg) {
+		new chai.Assertion(val).to.be.a.file(msg).and.deep.equal(exp, msg);
+	};
+
+	assert.notFileDeepEqual = function (val, exp, msg) {
+		new chai.Assertion(val).to.be.a.file(msg).and.not.deep.equal(exp, msg);
+	};
+};

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,6 +8,7 @@ module.exports = function (chai, utils) {
 	require('./assertions/name')(chai, utils);
 	require('./assertions/path')(chai, utils);
 	require('./assertions/file')(chai, utils);
+	require('./assertions/file_equal')(chai, utils);
 	require('./assertions/directory')(chai, utils);
 	require('./assertions/mode')(chai, utils);
 	require('./assertions/symlink')(chai, utils);

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "jshint-path-reporter": "~0.1",
     "mkdirp": "^0.5.0",
     "mocha-unfunk-reporter": "^0.4.0",
+    "touch": "^1.0.0",
     "underscore": "1.6.0"
   },
   "peerDependencies": {

--- a/test/init.js
+++ b/test/init.js
@@ -1,4 +1,5 @@
 var mkdirp = require('mkdirp');
+var touch = require('touch');
 var _ = require('underscore');
 
 var chai_fs = require('../lib/index');
@@ -23,6 +24,9 @@ before(function () {
 	assert.isDirectory('./test/fixtures');
 	assert.isDirectory('./test/fixtures/empty');
 	assert.isDirectory('./test/tmp');
+
+	// Change the times of alpha-copy.txt, so it will be equal, but not DEEP equal to alpha.txt
+	touch.sync('./test/fixtures/alpha-copy.txt', {time: '2016-01-01T00:00:00Z'});
 });
 
 describe('chai-fs', function () {

--- a/test/specs/file_equal.js
+++ b/test/specs/file_equal.js
@@ -1,0 +1,221 @@
+describe(require('path').basename(__filename), function () {
+
+	var chai = require('chai');
+	var expect = chai.expect;
+	var assert = chai.assert;
+
+	it('should leave an original equal() method unaffected', function(){
+		expect('abababa').to.equal('abababa');
+		expect('abababa').to.not.equal('cabadaba');
+		expect(12345).to.equal(12345);
+		expect(12345).to.not.equal(67890);
+		expect(true).to.equal(true);
+		expect(true).to.not.equal(false);
+	});
+
+	it('should leave an original deepEqual() method unaffected', function(){
+		var john = {name: { first: 'John', last: 'Doe' }, birthdate: new Date('1980-05-15')};
+		var john2 = {name: { first: 'John', last: 'Doe' }, birthdate: new Date('1980-05-15')};
+		var jane = {name: { first: 'Jane', last: 'Doe' }, birthdate: new Date('1982-11-25')};
+
+		expect(john).to.equal(john);
+		expect(john).to.not.equal(john2);
+		expect(john).to.deep.equal(john2);
+		expect(john).to.not.deep.equal(jane);
+	});
+
+	var styles = {
+		"expect/should": {
+			base: {
+				"basic": function (params) {
+					if (params.deep) {
+						expect(params.value).to.be.a.file().and.deep.equal(params.expected);
+						params.value.should.be.a.file().and.deep.equal(params.expected);
+					}
+					else {
+						expect(params.value).to.be.a.file().and.equal(params.expected);
+						params.value.should.be.a.file().and.equal(params.expected);
+					}
+				},
+				"with message": {msg: true, call: function (params) {
+					if (params.deep) {
+						expect(params.value).to.be.a.file(params.msg).and.deep.equal(params.expected, params.msg);
+						params.value.should.be.a.file(params.msg).and.deep.equal(params.expected, params.msg);
+					}
+					else {
+						expect(params.value).to.be.a.file(params.msg).and.equal(params.expected, params.msg);
+						params.value.should.be.a.file(params.msg).and.equal(params.expected, params.msg);
+					}
+				}}
+			},
+			negate: {
+				"basic": function (params) {
+					if (params.deep) {
+						expect(params.value).to.be.a.file().and.not.deep.equal(params.expected);
+						params.value.should.be.a.file().and.not.deep.equal(params.expected);
+					}
+					else {
+						expect(params.value).to.be.a.file().and.not.equal(params.expected);
+						params.value.should.be.a.file().and.not.equal(params.expected);
+					}
+				},
+				"with message": {msg: true, call: function (params) {
+					if (params.deep) {
+						expect(params.value).to.be.a.file(params.msg).and.not.deep.equal(params.expected, params.msg);
+						params.value.should.be.a.file(params.msg).and.not.deep.equal(params.expected, params.msg);
+					}
+					else {
+						expect(params.value).to.be.a.file(params.msg).and.not.equal(params.expected, params.msg);
+						params.value.should.be.a.file(params.msg).and.not.equal(params.expected, params.msg);
+					}
+				}}
+			}
+		},
+		assert: {
+			base: {
+				"basic": function (params) {
+					if (params.deep) {
+						assert.fileDeepEqual(params.value, params.expected);
+					}
+					else {
+						assert.fileEqual(params.value, params.expected);
+					}
+				},
+				"with message": {msg: true, call: function (params) {
+					if (params.deep) {
+						assert.fileDeepEqual(params.value, params.expected, params.msg);
+					}
+					else {
+						assert.fileEqual(params.value, params.expected, params.msg);
+					}
+				}}
+			},
+			negate: {
+				"basic": function (params) {
+					if (params.deep) {
+						assert.notFileDeepEqual(params.value, params.expected);
+					}
+					else {
+						assert.notFileEqual(params.value, params.expected);
+					}
+				},
+				"with message": {msg: true, call: function (params) {
+					if (params.deep) {
+						assert.notFileDeepEqual(params.value, params.expected, params.msg);
+					}
+					else {
+						assert.notFileEqual(params.value, params.expected, params.msg);
+					}
+				}}
+			}
+		}
+	};
+
+	var test = chai.getStyleTest(styles, {msg: 'My Message'});
+
+	test.valid({
+		label: 'same file',
+		value: 'test/fixtures/alpha.txt',
+		expected: 'test/fixtures/alpha.txt',
+		report: "expected '<%= value %>' not to equal <%= expected %>"
+	});
+	test.valid({
+		label: 'same file - deep',
+		deep: true,
+		value: 'test/fixtures/alpha.txt',
+		expected: 'test/fixtures/alpha.txt',
+		report: "expected '<%= value %>' not to deep equal <%= expected %>"
+	});
+
+	test.invalid({
+		label: 'different files',
+		value: 'test/fixtures/alpha.txt',
+		expected: 'test/fixtures/tango.txt',
+		report: "expected '<%= value %>' to equal <%= expected %>"
+	});
+	test.invalid({
+		label: 'different files - deep',
+		deep: true,
+		value: 'test/fixtures/alpha.txt',
+		expected: 'test/fixtures/tango.txt',
+		report: "expected '<%= value %>' to deep equal <%= expected %>"
+	});
+
+	test.valid({
+		label: 'different files, same contents',
+		value: 'test/fixtures/alpha.txt',
+		expected: 'test/fixtures/alpha-copy.txt',
+		report: "expected '<%= value %>' not to equal <%= expected %>"
+	});
+	test.invalid({
+		label: 'different files, same contents - deep',
+		deep: true,
+		value: 'test/fixtures/alpha.txt',
+		expected: 'test/fixtures/alpha-copy.txt',
+		report: "expected '<%= value %>' to deep equal <%= expected %> (last-modified times are different)"
+	});
+
+	test.valid({
+		label: 'empty file',
+		value: 'test/fixtures/empty.txt',
+		expected: 'test/fixtures/empty.txt',
+		report: "expected '<%= value %>' not to equal <%= expected %>"
+	});
+	test.valid({
+		label: 'empty file - deep',
+		deep: true,
+		value: 'test/fixtures/empty.txt',
+		expected: 'test/fixtures/empty.txt',
+		report: "expected '<%= value %>' not to deep equal <%= expected %>"
+	});
+
+	test.error({
+		label: 'not a file',
+		value: 'test/fixtures/dir',
+		report: "expected '<%= value %>' to be a file"
+	});
+	test.error({
+		label: 'not a file - deep',
+		deep: true,
+		value: 'test/fixtures/dir',
+		report: "expected '<%= value %>' to be a file"
+	});
+
+	test.error({
+		label: 'non-existing path',
+		value: 'test/fixtures/non-existing.txt',
+		report: "value: expected '<%= value %>' to exist"
+	});
+	test.error({
+		label: 'non-existing path - deep',
+		deep: true,
+		value: 'test/fixtures/non-existing.txt',
+		report: "value: expected '<%= value %>' to exist"
+	});
+
+	test.error({
+		label: 'bad expected type',
+		value: 'test/fixtures/alpha.txt',
+		expected: 123,
+		report: "expected-value: expected <%= expected %> to be a string"
+	});
+	test.error({
+		label: 'bad expected type - deep',
+		deep: true,
+		value: 'test/fixtures/alpha.txt',
+		expected: 123,
+		report: "expected-value: expected <%= expected %> to be a string"
+	});
+
+	test.error({
+		label: 'bad value type',
+		value: 123,
+		report: "value: expected <%= value %> to be a string"
+	});
+	test.error({
+		label: 'bad value type - deep',
+		deep: true,
+		value: 123,
+		report: "value: expected <%= value %> to be a string"
+	});
+});


### PR DESCRIPTION
Implemented file equality (compares contents) and deep-equality (compares contents, times, owner, and group) as mentioned on the [planned assertions page](https://github.com/chaijs/chai-fs/blob/master/docs/planned.md)
