### PR TITLE
Updated dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,19 +44,19 @@
     "bit-mask": "0.0.2-alpha"
   },
   "devDependencies": {
-    "chai": "latest",
-    "chai-json-schema": "1.0.4",
-    "grunt": "0.4.1",
-    "grunt-bump": "0.0.11",
-    "grunt-cli": "0.1",
-    "grunt-contrib-clean": "0.5.0",
-    "grunt-contrib-jshint": "^0.10.0",
-    "grunt-mocha-test": "^0.11.0",
+    "chai": "^2.3.0",
+    "chai-json-schema": "^1.2.0",
+    "grunt": "^1.0.1",
+    "grunt-bump": "^0.8.0",
+    "grunt-cli": "^1.2.0",
+    "grunt-contrib-clean": "^1.0.0",
+    "grunt-contrib-jshint": "^1.0.0",
+    "grunt-mocha-test": "^0.12.7",
     "jshint-path-reporter": "~0.1",
     "mkdirp": "^0.5.0",
     "mocha-unfunk-reporter": "^0.4.0",
     "touch": "^1.0.0",
-    "underscore": "1.6.0"
+    "underscore": "^1.8.3"
   },
   "peerDependencies": {
     "chai": ">= 1.6.1 < 4"

--- a/test/tester.js
+++ b/test/tester.js
@@ -83,7 +83,7 @@ module.exports = function (chai, _) {
 			throw( new Error('no report param'));
 		}
 
-		var report = _.template(params.report, params);
+		var report = _.template(params.report)(params);
 
 		_.each(styles, function (style, styleName) {
 			if (!style.hasOwnProperty(type)) {


### PR DESCRIPTION
Updated all dependencies and verified that all tests still pass.

- One small change was needed to `tester.js` due to a breaking change in Underscore

- I could not update the `chai` dependency due to conflicting peer-dependency restriction in `chai-json-schema`.  However, I tested it with the latest version of chai (3.5.0) and all tests still passed.

@keithamus - I'll submit a PR to update the peer-dependency in `chai-json-schema`.  Once that's merged, I can update the `chai` dependency in `chai-fs`.