### PR TITLE
Enhanced the `.content()` assertion syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,40 @@ Assert the path exists, is a file and has zero size.
 * Uses `fs.statSync().size === 0`.
 * To negate this using `expect/should` you chain the `.not`-negation ***after*** the regular `file()`.
 
+### file().with.content(str)
+
+Assert the path exists, is a file and has specific content.
+
+	expect(path).to.be.a.file(?msg).with.content(data, ?msg);
+	expect(path).to.be.a.file(?msg).and.not.have.content(data, ?msg);
+
+	path.should.be.a.file(?msg).with.content(data, ?msg);
+	path.should.be.a.file(?msg).and.not.have.content(data, ?msg);
+
+	assert.fileContent(path, data, ?msg);
+	assert.notFileContent(path, data, ?msg);
+
+* Reads file as utf8 text (could update to support base64, binary Buffer etc).
+* You can use `.content()` or `.contents()`. They're both the same.
+* To negate this using `expect/should` you chain the `.not`-negation ***after*** the regular `file()`.
+
+### file().with.contents.that.match(/xyz/)
+
+Assert the path exists, is a file and has contents that match the regular expression.
+
+	expect(path).to.be.a.file(?msg).with.contents.that.match(/xyz/, ?msg);
+	expect(path).to.be.a.file(?msg).and.not.have.contents.that.match(/xyz/, ?msg);
+
+	path.should.be.a.file(?msg).with.contents.that.match(/xyz/, ?msg);
+	path.should.be.a.file(?msg).and.not.have.contents.that.match(/xyz/, ?msg);
+
+	assert.fileContentMatch(path, /xyz/, ?msg);
+	assert.notFileContentMatch(path, /xyz/, ?msg);
+
+* Reads file as utf8 text (could update to support base64, binary Buffer etc).
+* You can use `.content` or `.contents`. They're both the same.
+* To negate this using `expect/should` you chain the `.not`-negation ***after*** the regular `file()`.
+
 ### file().and.equal(otherPath)
 
 Assert that _both_ paths exist, are files and contain the same content
@@ -176,7 +210,7 @@ Assert that _both_ paths exist, are files, contain the same content, and have th
  * last-changed time (`stats.ctime`)
  * last-access time (`stats.atime`)
 
-```
+
 	expect(path).to.be.a.file(?msg).and.deep.equal(otherPath, ?msg);
 	expect(path).to.be.a.file(?msg).and.not.deep.equal(otherPath, ?msg);
 
@@ -185,7 +219,6 @@ Assert that _both_ paths exist, are files, contain the same content, and have th
 
 	assert.fileDeepEqual(path, otherPath, ?msg);
 	assert.notFileDeepEqual(path, otherPath, ?msg);
-```
 
 * Reads both files as utf8 text (could update to support base64, binary Buffer etc).
 * To negate this using `expect/should` you chain the `.not`-negation ***after*** the regular `file()`.
@@ -225,38 +258,6 @@ Assert the path exists, is a file, contains json parsable text conforming to giv
 * Depends on the [chai-json-schema](https://github.com/chaijs/chai-json-schema) plugin to be separately activated with `chai.use()`.
 * To negate this using `expect/should` you chain the `.not`-negation ***after*** the regular `json`.
 * The `with` and `using` chains are just syntax sugar.
-
-### content()
-
-Assert the path exists, is a file and has specific content.
-
-	expect(path).to.have.content(data, ?msg);
-	expect(path).to.not.have.content(data, ?msg);
-
-	path.should.have.content(data, ?msg);
-	path.should.not.have.content(data, ?msg);
-
-	assert.fileContent(path, data, ?msg);
-	assert.notFileContent(path, data, ?msg);
-
-* Reads file as utf8 text (could update to support base64, binary Buffer etc).
-
-Note: *In a future version this might be supported as a chain behind file() and directory()*
-
-### content.that.match(/xyz/)
-
-Assert the path exists, is a file and has contents that match the regular expression.
-
-	expect(path).to.have.content.that.match(/xyz/, ?msg);
-	expect(path).to.not.have.content.that.match(/xyz/, ?msg);
-
-	path.should.have.content.that.match(/xyz/, ?msg);
-	path.should.not.have.content.that.match(/xyz/, ?msg);
-
-	assert.fileContentMatch(path, /xyz/, ?msg);
-	assert.notFileContentMatch(path, /xyz/, ?msg);
-
-* Reads file as utf8 text (could update to support base64, binary Buffer etc).
 
 ###  Planned assertions
 

--- a/lib/assertions/content.js
+++ b/lib/assertions/content.js
@@ -20,9 +20,11 @@ module.exports = function (chai, utils) {
 
 		var obj = this._obj;
 
-		new chai.Assertion(obj, preMsg + 'value').is.a('string');
-		new chai.Assertion(obj, preMsg + 'value').to.be.a.path();
-		new chai.Assertion(obj, preMsg + 'value').to.be.a.file();
+		if (!flag(this, 'fs.isFile')) {
+			new chai.Assertion(obj, preMsg + 'value').is.a('string');
+			new chai.Assertion(obj, preMsg + 'value').to.be.a.path();
+			new chai.Assertion(obj, preMsg + 'value').to.be.a.file();
+		}
 
 		new chai.Assertion(expected, preMsg + 'expected-value').is.a('string');
 
@@ -44,6 +46,7 @@ module.exports = function (chai, utils) {
   };
 
 	Assertion.addChainableMethod('content', contentMethod, chainingBehavior);
+	Assertion.addChainableMethod('contents', contentMethod, chainingBehavior);
 
 	assert.fileContent = function (val, exp, msg) {
 		new chai.Assertion(val).to.have.content(exp, msg);

--- a/lib/assertions/content_match.js
+++ b/lib/assertions/content_match.js
@@ -23,9 +23,11 @@ module.exports = function (chai, utils) {
 					preMsg = msg + ': ';
 				}
 
-				new chai.Assertion(obj, preMsg + 'value').is.a('string');
-				new chai.Assertion(obj, preMsg + 'value').to.be.a.path();
-				new chai.Assertion(obj, preMsg + 'value').to.be.a.file();
+				if (!flag(this, 'fs.isFile')) {
+					new chai.Assertion(obj, preMsg + 'value').is.a('string');
+					new chai.Assertion(obj, preMsg + 'value').to.be.a.path();
+					new chai.Assertion(obj, preMsg + 'value').to.be.a.file();
+				}
 
 				new chai.Assertion(expected, preMsg + 'expected-value').is.an
 					.instanceof(RegExp);

--- a/test/specs/file_content.js
+++ b/test/specs/file_content.js
@@ -9,16 +9,34 @@ describe(require('path').basename(__filename), function () {
 			base: {
 				"basic": function (params) {
 					expect(params.value).to.have.content(params.expected);
+					expect(params.value).to.have.contents(params.expected);
+					expect(params.value).to.be.a.file().with.content(params.expected);
+					expect(params.value).to.be.a.file().with.contents(params.expected);
 					params.value.should.have.content(params.expected);
+					params.value.should.have.contents(params.expected);
+					params.value.should.be.a.file().with.content(params.expected);
+					params.value.should.be.a.file().with.contents(params.expected);
 				},
 				"with message": {msg: true, call: function (params) {
 					expect(params.value).to.have.content(params.expected, params.msg);
+					expect(params.value).to.have.contents(params.expected, params.msg);
+					expect(params.value).to.be.a.file(params.msg).with.content(params.expected, params.msg);
+					expect(params.value).to.be.a.file(params.msg).with.contents(params.expected, params.msg);
 					params.value.should.have.content(params.expected, params.msg);
+					params.value.should.have.contents(params.expected, params.msg);
+					params.value.should.be.a.file(params.msg).with.content(params.expected, params.msg);
+					params.value.should.be.a.file(params.msg).with.contents(params.expected, params.msg);
 				}}
 			},
 			negate: function (params) {
 				expect(params.value).to.not.have.content(params.expected);
+				expect(params.value).to.not.have.contents(params.expected);
+				expect(params.value).to.be.a.file().and.not.have.content(params.expected);
+				expect(params.value).to.be.a.file().and.not.have.contents(params.expected);
 				params.value.should.not.have.content(params.expected);
+				params.value.should.not.have.contents(params.expected);
+				params.value.should.be.a.file().and.not.have.content(params.expected);
+				params.value.should.be.a.file().and.not.have.contents(params.expected);
 			}
 		},
 		assert: {

--- a/test/specs/file_content_match.js
+++ b/test/specs/file_content_match.js
@@ -14,16 +14,34 @@ describe(require('path').basename(__filename), function () {
 			base: {
 				"basic": function (params) {
 					expect(params.value).to.have.content.that.match(params.expected);
+					expect(params.value).to.have.contents.that.match(params.expected);
+					expect(params.value).to.be.a.file().with.content.that.match(params.expected);
+					expect(params.value).to.be.a.file().with.contents.that.match(params.expected);
 					params.value.should.have.content.that.match(params.expected);
+					params.value.should.have.contents.that.match(params.expected);
+					params.value.should.be.a.file().with.content.that.match(params.expected);
+					params.value.should.be.a.file().with.contents.that.match(params.expected);
 				},
 				"with message": {msg: true, call: function (params) {
 					expect(params.value).to.have.content.that.match(params.expected, params.msg);
+					expect(params.value).to.have.contents.that.match(params.expected, params.msg);
+					expect(params.value).to.be.a.file(params.msg).with.content.that.match(params.expected, params.msg);
+					expect(params.value).to.be.a.file(params.msg).with.contents.that.match(params.expected, params.msg);
 					params.value.should.have.content.that.match(params.expected, params.msg);
+					params.value.should.have.contents.that.match(params.expected, params.msg);
+					params.value.should.be.a.file(params.msg).with.content.that.match(params.expected, params.msg);
+					params.value.should.be.a.file(params.msg).with.contents.that.match(params.expected, params.msg);
 				}}
 			},
 			negate: function (params) {
 				expect(params.value).to.not.have.content.that.match(params.expected);
+				expect(params.value).to.not.have.contents.that.match(params.expected);
+				expect(params.value).to.be.a.file().and.not.have.content.that.match(params.expected);
+				expect(params.value).to.be.a.file().and.not.have.contents.that.match(params.expected);
 				params.value.should.not.have.content.that.match(params.expected);
+				params.value.should.not.have.contents.that.match(params.expected);
+				params.value.should.be.a.file().and.not.have.content.that.match(params.expected);
+				params.value.should.be.a.file().and.not.have.contents.that.match(params.expected);
 
 			}
 		},
@@ -52,7 +70,7 @@ describe(require('path').basename(__filename), function () {
 		msg: 'My Message',
 		value: 'test/fixtures/alpha.txt',
 		actual: fs.readFileSync('test/fixtures/alpha.txt', 'utf8'),
-		expected: /pha F/ 
+		expected: /pha F/
 	};
 
 	var test = chai.getStyleTest(styles, defaults);


### PR DESCRIPTION
This PR enhances the `.content()` and `.content.that.match()` assertion syntax in two ways:

1. **Consistent chaining behavior**<br>
The `.content()` assertions can now be chained behind `.file()`, which is more consistent with other `chai-fs` assertions and may be more readable/preferable to some people.  The existing syntax (without chaining behind `.file()`) still works as well.  For example, the following are identical:

```
// These two are the same
expect(path).to.have.content(data);
expect(path).to.be.a.file().with.content(data);

// These two are the same
expect(path).to.not.have.content(data);
expect(path).to.be.a.file().and.not.have.content(data);
```

2. **Plural alias**<br>
Added an plural (`.contents()`), which is just an alias and behaves identically.  This just allows certain chaining structures to read more like English.

```
// These two are the same
expect(path).to.be.a.file().with.content(data);
expect(path).to.be.a.file().with.contents(data);
```

----------------------------------------------

Both of these changes improve readability & consistency of `chai-fs`, and they will also both be useful for my next pull request (which I'll probably submit tomorrow), which enhances the `.content` assertion to support _directory_ contents in addition to file contents.  That'll look like this:

```
// Assert the top-level contents of a directory
expect(path).to.be.a.directory().with.contents(["file1.txt", "file2.txt", "subdir1", "subdir2"]);

// Assert the deep contents of a directory
expect(path).to.be.a.directory().with.deep.contents([
  "file1.txt", "file2.txt", 
  "subdir1", "subdir1/file3.txt", "subdir1/file4.txt",
  "subdir2", "subdir2/file5.txt", "subdir2/file6.txt",
  "subdir2/subdir3", "subdir2/subdir3/file7.txt", "subdir2/subdir3/file8.txt"
]);

// Assert that two directories have the same top-level contents
expect(path).to.be.a.directory().and.equal(otherPath);

// Assert that two directories have the same deep contents
expect(path).to.be.a.directory().and.deep.equal(otherPath);
```

