### PR TITLE
Added missing quotation marks in assertion error messages

### DIFF
--- a/lib/assertions/file_equal.js
+++ b/lib/assertions/file_equal.js
@@ -73,8 +73,8 @@ module.exports = function (chai, utils) {
 
 				this.assert(
 					pass
-					, format('expected #{this} to %sequal %s%s', deep, expected, details)
-					, format('expected #{this} not to %sequal %s%s', deep, expected, details)
+					, format("expected #{this} to %sequal '%s'%s", deep, expected, details)
+					, format("expected #{this} not to %sequal '%s'%s", deep, expected, details)
 					, expectedValue
 					, actualValue
 					, true 	// show diff

--- a/test/specs/file_equal.js
+++ b/test/specs/file_equal.js
@@ -117,56 +117,56 @@ describe(require('path').basename(__filename), function () {
 		label: 'same file',
 		value: 'test/fixtures/alpha.txt',
 		expected: 'test/fixtures/alpha.txt',
-		report: "expected '<%= value %>' not to equal <%= expected %>"
+		report: "expected '<%= value %>' not to equal '<%= expected %>'"
 	});
 	test.valid({
 		label: 'same file - deep',
 		deep: true,
 		value: 'test/fixtures/alpha.txt',
 		expected: 'test/fixtures/alpha.txt',
-		report: "expected '<%= value %>' not to deep equal <%= expected %>"
+		report: "expected '<%= value %>' not to deep equal '<%= expected %>'"
 	});
 
 	test.invalid({
 		label: 'different files',
 		value: 'test/fixtures/alpha.txt',
 		expected: 'test/fixtures/tango.txt',
-		report: "expected '<%= value %>' to equal <%= expected %>"
+		report: "expected '<%= value %>' to equal '<%= expected %>'"
 	});
 	test.invalid({
 		label: 'different files - deep',
 		deep: true,
 		value: 'test/fixtures/alpha.txt',
 		expected: 'test/fixtures/tango.txt',
-		report: "expected '<%= value %>' to deep equal <%= expected %>"
+		report: "expected '<%= value %>' to deep equal '<%= expected %>'"
 	});
 
 	test.valid({
 		label: 'different files, same contents',
 		value: 'test/fixtures/alpha.txt',
 		expected: 'test/fixtures/alpha-copy.txt',
-		report: "expected '<%= value %>' not to equal <%= expected %>"
+		report: "expected '<%= value %>' not to equal '<%= expected %>'"
 	});
 	test.invalid({
 		label: 'different files, same contents - deep',
 		deep: true,
 		value: 'test/fixtures/alpha.txt',
 		expected: 'test/fixtures/alpha-copy.txt',
-		report: "expected '<%= value %>' to deep equal <%= expected %> (last-modified times are different)"
+		report: "expected '<%= value %>' to deep equal '<%= expected %>' (last-modified times are different)"
 	});
 
 	test.valid({
 		label: 'empty file',
 		value: 'test/fixtures/empty.txt',
 		expected: 'test/fixtures/empty.txt',
-		report: "expected '<%= value %>' not to equal <%= expected %>"
+		report: "expected '<%= value %>' not to equal '<%= expected %>'"
 	});
 	test.valid({
 		label: 'empty file - deep',
 		deep: true,
 		value: 'test/fixtures/empty.txt',
 		expected: 'test/fixtures/empty.txt',
-		report: "expected '<%= value %>' not to deep equal <%= expected %>"
+		report: "expected '<%= value %>' not to deep equal '<%= expected %>'"
 	});
 
 	test.error({


### PR DESCRIPTION
This is just a minor change for consistency.  The error messages for the `file_equal` assertion were missing quotes around the file name.