### PR TITLE
Added new assertions for comparing directory contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Uses `fs.statSync().isDirectory()`
 
 ### directory().and.empty
 
-Assert the path exists, is a directory and contains zero item.
+Assert the path exists, is a directory and contains zero items.
 
 	expect(path).to.be.a.directory(?msg).and.empty;
 	expect(path).to.be.a.directory(?msg).and.not.empty;
@@ -115,6 +115,140 @@ Assert the path exists, is a directory and contains zero item.
 
 * Chains after `directory()`
 * Uses `fs.readdirSync().length === 0`.
+* To negate this using `expect/should` you chain the `.not`-negation ***after*** the regular `directory()`.
+
+### directory().with.contents([...])
+
+Assert the path exists, is a directory and has specific contents (files, sub-directories, symlinks, etc).
+
+	expect(path).to.be.a.directory(?msg).with.contents(array, ?msg);
+	expect(path).to.be.a.directory(?msg).and.not.have.contents(array, ?msg);
+	expect(path).to.be.a.directory(?msg).with.deep.contents(array, ?msg);
+	expect(path).to.be.a.directory(?msg).and.not.have.deep.contents(array, ?msg);
+	expect(path).to.be.a.directory(?msg).and.include.contents(array, ?msg);
+	expect(path).to.be.a.directory(?msg).and.not.include.contents(array, ?msg);
+
+	path.should.be.a.directory(?msg).with.contents(array, ?msg);
+	path.should.be.a.directory(?msg).and.not.have.contents(array, ?msg);
+	path.should.be.a.directory(?msg).with.deep.contents(array, ?msg);
+	path.should.be.a.directory(?msg).and.not.have.deep.contents(array, ?msg);
+	path.should.be.a.directory(?msg).and.include.contents(array, ?msg);
+	path.should.be.a.directory(?msg).and.not.include.contents(array, ?msg);
+
+	assert.directoryContent(path, array, ?msg);
+	assert.notDirectoryContent(path, array, ?msg);
+	assert.directoryDeepContent(path, array, ?msg);
+	assert.notDirectoryDeepContent(path, array, ?msg);
+	assert.directoryInclude(path, array, ?msg);
+	assert.notDirectoryInclude(path, array, ?msg);
+
+* The paths of contents are relative to the directory
+* Only the top level contents are included, unless `.deep` is in the chain
+* If `.include` or `.contain` is in the chain, then the directory must contain _at least_ the specified contents, but may contain more
+* You can use `.content()` or `.contents()`. They're both the same.
+* To negate this using `expect/should` you chain the `.not`-negation ***after*** the regular `directory()`.
+
+### directory().with.files([...])
+
+Assert the path exists, is a directory and contains specific files.
+
+	expect(path).to.be.a.directory(?msg).with.files(array, ?msg);
+	expect(path).to.be.a.directory(?msg).and.not.have.files(array, ?msg);
+	expect(path).to.be.a.directory(?msg).with.deep.files(array, ?msg);
+	expect(path).to.be.a.directory(?msg).and.not.have.deep.files(array, ?msg);
+	expect(path).to.be.a.directory(?msg).and.include.files(array, ?msg);
+	expect(path).to.be.a.directory(?msg).and.not.include.files(array, ?msg);
+
+	path.should.be.a.directory(?msg).with.files(array, ?msg);
+	path.should.be.a.directory(?msg).and.not.have.files(array, ?msg);
+	path.should.be.a.directory(?msg).with.deep.files(array, ?msg);
+	path.should.be.a.directory(?msg).and.not.have.deep.files(array, ?msg);
+	path.should.be.a.directory(?msg).and.include.files(array, ?msg);
+	path.should.be.a.directory(?msg).and.not.include.files(array, ?msg);
+
+	assert.directoryFiles(path, array, ?msg);
+	assert.notDirectoryFiles(path, array, ?msg);
+	assert.directoryDeepFiles(path, array, ?msg);
+	assert.notDirectoryDeepFiles(path, array, ?msg);
+	assert.directoryIncludeFiles(path, array, ?msg);
+	assert.notDirectoryIncludeFiles(path, array, ?msg);
+
+* The file paths are relative to the directory
+* Only the top level files are included, unless `.deep` is in the chain
+* If `.include` or `.contain` is in the chain, then the directory must contain _at least_ the specified files, but may contain more
+* To negate this using `expect/should` you chain the `.not`-negation ***after*** the regular `directory()`.
+
+### directory().with.subDirs([...])
+
+Assert the path exists, is a directory and contains specific sub-directories.
+
+	expect(path).to.be.a.directory(?msg).with.subDirs(array, ?msg);
+	expect(path).to.be.a.directory(?msg).and.not.have.subDirs(array, ?msg);
+	expect(path).to.be.a.directory(?msg).with.deep.subDirs(array, ?msg);
+	expect(path).to.be.a.directory(?msg).and.not.have.deep.subDirs(array, ?msg);
+	expect(path).to.be.a.directory(?msg).and.include.subDirs(array, ?msg);
+	expect(path).to.be.a.directory(?msg).and.not.include.subDirs(array, ?msg);
+
+	path.should.be.a.directory(?msg).with.subDirs(array, ?msg);
+	path.should.be.a.directory(?msg).and.not.have.subDirs(array, ?msg);
+	path.should.be.a.directory(?msg).with.deep.subDirs(array, ?msg);
+	path.should.be.a.directory(?msg).and.not.have.deep.subDirs(array, ?msg);
+	path.should.be.a.directory(?msg).and.include.subDirs(array, ?msg);
+	path.should.be.a.directory(?msg).and.not.include.subDirs(array, ?msg);
+
+	assert.directorySubDirs(path, array, ?msg);
+	assert.notDirectorySubDirs(path, array, ?msg);
+	assert.directoryDeepSubDirs(path, array, ?msg);
+	assert.notDirectoryDeepSubDirs(path, array, ?msg);
+	assert.directoryIncludeSubDirs(path, array, ?msg);
+	assert.notDirectoryIncludeSubDirs(path, array, ?msg);
+
+* The paths of contents are relative to the starting directory
+* Only the top level sub-directories are included, unless `.deep` is in the chain
+* If `.include` or `.contain` is in the chain, then the directory must contain _at least_ the specified sub-directories, but may contain more
+* To negate this using `expect/should` you chain the `.not`-negation ***after*** the regular `directory()`.
+
+### directory().with.contents.that.satisfy(fn)
+
+You can chain `.contents`, `.files`, and `.subDirs` with any Chai.js assertion that can operate on an array, including `.lengthOf()`, `.satisfy()`, `.members()`, etc.
+
+	expect(path).to.be.a.directory().and.content.is.an('array');
+
+	expect(path).to.be.a.directory().and.files.have.lengthOf(5);
+
+	path.should.be.a.directory().with.subDirs.that.include.members(['subDir1', 'subDir2']);
+
+	path.should.be.a.directory().with.files.that.satisfy(function(files) {
+	  return files.every(function(file) {
+	    return file.substr(-4) === '.txt';
+	  });
+	})
+
+* The paths of contents are relative to the directory
+* Only the top level contents are included, unless `.deep` is in the chain
+* You can use `.content()` or `.contents()`. They're both the same.
+* To negate this using `expect/should` you chain the `.not`-negation ***after*** the regular `directory()`.
+
+### directory().and.equal(otherPath)
+
+Assert that _both_ paths exist, are directories and contain the same contents (files, sub-directories, symlinks, etc).
+
+	expect(path).to.be.a.directory(?msg).and.equal(otherPath, ?msg);
+	expect(path).to.be.a.directory(?msg).and.not.equal(otherPath, ?msg);
+	expect(path).to.be.a.directory(?msg).and.deep.equal(otherPath, ?msg);
+	expect(path).to.be.a.directory(?msg).and.not.deep.equal(otherPath, ?msg);
+
+	path.should.be.a.directory(?msg).and.equal(otherPath, ?msg);
+	path.should.be.a.directory(?msg).and.not.equal(otherPath, ?msg);
+	path.should.be.a.directory(?msg).and.deep.equal(otherPath, ?msg);
+	path.should.be.a.directory(?msg).and.not.deep.equal(otherPath, ?msg);
+
+	assert.directoryEqual(path, otherPath, ?msg);
+	assert.notDirectoryEqual(path, otherPath, ?msg);
+	assert.directoryDeepEqual(path, otherPath, ?msg);
+	assert.notDirectoryDeepEqual(path, otherPath, ?msg);
+
+* Only the top level contents are compared, unless `.deep` is in the chain
 * To negate this using `expect/should` you chain the `.not`-negation ***after*** the regular `directory()`.
 
 ### file()

--- a/lib/assertions/directory_content.js
+++ b/lib/assertions/directory_content.js
@@ -11,10 +11,10 @@ module.exports = function (chai, utils) {
 	//-------------------------------------------------------------------------------------------------------------
 
 	function directoryContentAssertion (label, expectedContents, msg) {
+		var deep = Boolean(flag(this, 'deep'));
+		var contains = Boolean(flag(this, 'contains'));
 		var dir = flag(this, 'fs.path');
-		var deep = !!flag(this, 'deep');
 		var actualContents = flag(this, 'object');
-		var contains = !!flag(this, 'contains');
 
 		var preMsg = '';
 		if (msg) {
@@ -65,7 +65,7 @@ module.exports = function (chai, utils) {
 
 	function directoryContentChainingBehavior (filter) {
 		var dir = flag(this, 'object');
-		var deep = !!flag(this, 'deep');
+		var deep = Boolean(flag(this, 'deep'));
 
 		// Read the directory, possibly recursively.
 		var contents = readdir.sync(dir, {

--- a/lib/assertions/directory_content.js
+++ b/lib/assertions/directory_content.js
@@ -1,6 +1,7 @@
 module.exports = function (chai, utils) {
 
 	var Assertion = chai.Assertion;
+	var AssertionError = chai.AssertionError;
 	var flag = utils.flag;
 	var assert = chai.assert;
 
@@ -43,8 +44,13 @@ module.exports = function (chai, utils) {
 			}
 			pass = true;
 		}
-		catch (e) {
-			pass = false;
+		catch (err) {
+			if (err instanceof AssertionError) {
+				pass = false;
+			}
+			else {
+				throw err;
+			}
 		}
 
 		this.assert(

--- a/lib/assertions/directory_content.js
+++ b/lib/assertions/directory_content.js
@@ -1,0 +1,207 @@
+module.exports = function (chai, utils) {
+
+	var Assertion = chai.Assertion;
+	var flag = utils.flag;
+	var assert = chai.assert;
+
+	var readdir = require('readdir-enhanced');
+	var format = require('util').format;
+
+	//-------------------------------------------------------------------------------------------------------------
+
+	function directoryContentAssertion (label, expectedContents, msg) {
+		var dir = flag(this, 'fs.path');
+		var deep = !!flag(this, 'deep');
+		var actualContents = flag(this, 'object');
+		var contains = !!flag(this, 'contains');
+
+		var preMsg = '';
+		if (msg) {
+			flag(this, 'message', msg);
+			preMsg = msg + ': ';
+		}
+
+		new chai.Assertion(expectedContents, preMsg + 'expected-value').is.an('array');
+
+		actualContents.sort();
+		expectedContents.sort();
+
+		if (deep) {
+			label = 'deep ' + label;
+		}
+
+		var pass, failMsg, failNegateMsg;
+		try {
+			if (contains) {
+				failMsg = format("expected '%s' to contain %s #{exp}", dir, label);
+				failNegateMsg = format("expected '%s' to not contain %s #{exp}", dir, label);
+				new chai.Assertion(actualContents, msg).contains.members(expectedContents, msg);
+			} else {
+				failMsg = format("expected '%s' to have the same %s as #{exp}", dir, label);
+				failNegateMsg = format("expected '%s' to not have the same %s as #{exp}", dir, label);
+				new chai.Assertion(actualContents, msg).has.members(expectedContents, msg);
+			}
+			pass = true;
+		}
+		catch (e) {
+			pass = false;
+		}
+
+		this.assert(
+			pass
+			, failMsg
+			, failNegateMsg
+			, expectedContents
+			, actualContents
+			, true 	// show diff
+		);
+	}
+
+	function directoryContentChainingBehavior (filter) {
+		var dir = flag(this, 'object');
+		var deep = !!flag(this, 'deep');
+
+		// Read the directory, possibly recursively.
+		var contents = readdir.sync(dir, {
+			deep: deep,				// deep vs shallow
+			filter: filter, 	// Filter by files or directories
+			sep: '/'					// Always use "/" path separators, so tests work consistently across platforms
+		});
+
+		// Replace the current assertion value (the directory path), with the
+		// directory contents (array), so it can be chained with normal array assertions
+		// (e.g. `content.have.lengthOf(5)` or `content.that.satisfy(criteria)`)
+		utils.flag(this, 'object', contents);
+
+		// Change the flags to reflect the new value
+		flag(this, 'fs.isDirectory', false);
+		flag(this, 'fs.directoryContent', true);
+		flag(this, 'fs.path', dir);
+	}
+
+	function overwriteContentAssertion (_super) {
+		return function dirContentMethod(expectedContents, msg) {
+			if (flag(this, 'fs.directoryContent')) {
+				directoryContentAssertion.call(this, 'contents', expectedContents, msg);
+			} else {
+				_super.apply(this, arguments);
+			}
+		};
+	}
+
+	function overwriteContentChainingBehavior (_super) {
+		return function dirContentProperty() {
+			if (flag(this, 'fs.isDirectory')) {
+				directoryContentChainingBehavior.call(this, null);
+			}
+			else {
+				_super.apply(this, arguments);
+			}
+		};
+	}
+
+	Assertion.overwriteChainableMethod('content', overwriteContentAssertion, overwriteContentChainingBehavior);
+	Assertion.overwriteChainableMethod('contents', overwriteContentAssertion, overwriteContentChainingBehavior);
+
+	Assertion.addChainableMethod('files',
+		function(expectedFiles, msg) {
+			directoryContentAssertion.call(this, 'files', expectedFiles, msg);
+		},
+		function() {
+			directoryContentChainingBehavior.call(this, function fileFilter (stats) {
+				return stats.isFile();
+			});
+		}
+	);
+
+	Assertion.addChainableMethod('subDirs',
+		function(expectedSubDirs, msg) {
+			directoryContentAssertion.call(this, 'sub-directories', expectedSubDirs, msg);
+		},
+		function() {
+			directoryContentChainingBehavior.call(this, function dirFilter (stats) {
+				return stats.isDirectory();
+			});
+		}
+	);
+
+	assert.directoryContent = function (val, exp, msg) {
+		new chai.Assertion(val).to.be.a.directory(msg).with.contents(exp, msg);
+	};
+	assert.directoryFiles = function (val, exp, msg) {
+		new chai.Assertion(val).to.be.a.directory(msg).with.files(exp, msg);
+	};
+	assert.directorySubDirs = function (val, exp, msg) {
+		new chai.Assertion(val).to.be.a.directory(msg).with.subDirs(exp, msg);
+	};
+
+	assert.notDirectoryContent = function (val, exp, msg) {
+		new chai.Assertion(val).to.be.a.directory(msg).and.not.have.contents(exp, msg);
+	};
+	assert.notDirectoryFiles = function (val, exp, msg) {
+		new chai.Assertion(val).to.be.a.directory(msg).and.not.have.files(exp, msg);
+	};
+	assert.notDirectorySubDirs = function (val, exp, msg) {
+		new chai.Assertion(val).to.be.a.directory(msg).and.not.have.subDirs(exp, msg);
+	};
+
+	assert.directoryDeepContent = function (val, exp, msg) {
+		new chai.Assertion(val).to.be.a.directory(msg).with.deep.contents(exp, msg);
+	};
+	assert.directoryDeepFiles = function (val, exp, msg) {
+		new chai.Assertion(val).to.be.a.directory(msg).with.deep.files(exp, msg);
+	};
+	assert.directoryDeepSubDirs = function (val, exp, msg) {
+		new chai.Assertion(val).to.be.a.directory(msg).with.deep.subDirs(exp, msg);
+	};
+
+	assert.notDirectoryDeepContent = function (val, exp, msg) {
+		new chai.Assertion(val).to.be.a.directory(msg).and.not.have.deep.contents(exp, msg);
+	};
+	assert.notDirectoryDeepFiles = function (val, exp, msg) {
+		new chai.Assertion(val).to.be.a.directory(msg).and.not.have.deep.files(exp, msg);
+	};
+	assert.notDirectoryDeepSubDirs = function (val, exp, msg) {
+		new chai.Assertion(val).to.be.a.directory(msg).and.not.have.deep.subDirs(exp, msg);
+	};
+
+	assert.directoryInclude = function (val, exp, msg) {
+		new chai.Assertion(val).to.be.a.directory(msg).and.include.contents(exp, msg);
+	};
+	assert.directoryIncludeFiles = function (val, exp, msg) {
+		new chai.Assertion(val).to.be.a.directory(msg).and.include.files(exp, msg);
+	};
+	assert.directoryIncludeSubDirs = function (val, exp, msg) {
+		new chai.Assertion(val).to.be.a.directory(msg).and.include.subDirs(exp, msg);
+	};
+
+	assert.notDirectoryInclude = function (val, exp, msg) {
+		new chai.Assertion(val).to.be.a.directory(msg).and.not.include.contents(exp, msg);
+	};
+	assert.notDirectoryIncludeFiles = function (val, exp, msg) {
+		new chai.Assertion(val).to.be.a.directory(msg).and.not.include.files(exp, msg);
+	};
+	assert.notDirectoryIncludeSubDirs = function (val, exp, msg) {
+		new chai.Assertion(val).to.be.a.directory(msg).and.not.include.subDirs(exp, msg);
+	};
+
+	assert.directoryDeepInclude = function (val, exp, msg) {
+		new chai.Assertion(val).to.be.a.directory(msg).and.include.deep.contents(exp, msg);
+	};
+	assert.directoryDeepIncludeFiles = function (val, exp, msg) {
+		new chai.Assertion(val).to.be.a.directory(msg).and.include.deep.files(exp, msg);
+	};
+	assert.directoryDeepIncludeSubDirs = function (val, exp, msg) {
+		new chai.Assertion(val).to.be.a.directory(msg).and.include.deep.subDirs(exp, msg);
+	};
+
+	assert.notDirectoryDeepInclude = function (val, exp, msg) {
+		new chai.Assertion(val).to.be.a.directory(msg).and.not.include.deep.contents(exp, msg);
+	};
+	assert.notDirectoryDeepIncludeFiles = function (val, exp, msg) {
+		new chai.Assertion(val).to.be.a.directory(msg).and.not.include.deep.files(exp, msg);
+	};
+	assert.notDirectoryDeepIncludeSubDirs = function (val, exp, msg) {
+		new chai.Assertion(val).to.be.a.directory(msg).and.not.include.deep.subDirs(exp, msg);
+	};
+};

--- a/lib/assertions/directory_equal.js
+++ b/lib/assertions/directory_equal.js
@@ -26,8 +26,8 @@ module.exports = function (chai, utils) {
 				new chai.Assertion(expected, preMsg + 'expected-value').to.be.a.path();
 				new chai.Assertion(expected, preMsg + 'expected-value').to.be.a.directory();
 
-				var actualContents = readdir.sync(obj, {deep: !!deep, sep: '/'}).sort();
-				var expectedContents = readdir.sync(expected, {deep: !!deep, sep: '/'}).sort();
+				var actualContents = readdir.sync(obj, {deep: Boolean(deep), sep: '/'}).sort();
+				var expectedContents = readdir.sync(expected, {deep: Boolean(deep), sep: '/'}).sort();
 
 				var pass;
 				try {

--- a/lib/assertions/directory_equal.js
+++ b/lib/assertions/directory_equal.js
@@ -1,6 +1,7 @@
 module.exports = function (chai, utils) {
 
 	var Assertion = chai.Assertion;
+	var AssertionError = chai.AssertionError;
 	var flag = utils.flag;
 	var assert = chai.assert;
 
@@ -33,8 +34,13 @@ module.exports = function (chai, utils) {
 					new chai.Assertion(actualContents, msg).has.same.members(expectedContents, msg);
 					pass = true;
 				}
-				catch (e) {
-					pass = false;
+				catch (err) {
+					if (err instanceof AssertionError) {
+						pass = false;
+					}
+					else {
+						throw err;
+					}
 				}
 
 				this.assert(

--- a/lib/assertions/directory_equal.js
+++ b/lib/assertions/directory_equal.js
@@ -1,0 +1,69 @@
+module.exports = function (chai, utils) {
+
+	var Assertion = chai.Assertion;
+	var flag = utils.flag;
+	var assert = chai.assert;
+
+	var readdir = require('readdir-enhanced');
+	var format = require('util').format;
+
+	//-------------------------------------------------------------------------------------------------------------
+
+	Assertion.overwriteMethod('equal', function (_super) {
+		return function dirEqual (expected, msg) {
+			if (flag(this, 'fs.isDirectory')) {
+				var deep = flag(this, 'deep') ? 'deep ' : '';
+
+				var obj = this._obj;
+				var preMsg = '';
+				if (msg) {
+					flag(this, 'message', msg);
+					preMsg = msg + ': ';
+				}
+
+				new chai.Assertion(expected, preMsg + 'expected-value').is.a('string');
+				new chai.Assertion(expected, preMsg + 'expected-value').to.be.a.path();
+				new chai.Assertion(expected, preMsg + 'expected-value').to.be.a.directory();
+
+				var actualContents = readdir.sync(obj, {deep: !!deep, sep: '/'}).sort();
+				var expectedContents = readdir.sync(expected, {deep: !!deep, sep: '/'}).sort();
+
+				var pass;
+				try {
+					new chai.Assertion(actualContents, msg).has.same.members(expectedContents, msg);
+					pass = true;
+				}
+				catch (e) {
+					pass = false;
+				}
+
+				this.assert(
+					pass
+					, format("expected #{this} to %sequal '%s'", deep, expected)
+					, format("expected #{this} not to %sequal '%s'", deep, expected)
+					, expectedContents
+					, actualContents
+					, true 	// show diff
+				);
+			} else {
+				_super.apply(this, arguments);
+			}
+		};
+	});
+
+	assert.directoryEqual = function (val, exp, msg) {
+		new chai.Assertion(val).to.be.a.directory(msg).and.equal(exp, msg);
+	};
+
+	assert.notDirectoryEqual = function (val, exp, msg) {
+		new chai.Assertion(val).to.be.a.directory(msg).and.not.equal(exp, msg);
+	};
+
+	assert.directoryDeepEqual = function (val, exp, msg) {
+		new chai.Assertion(val).to.be.a.directory(msg).and.deep.equal(exp, msg);
+	};
+
+	assert.notDirectoryDeepEqual = function (val, exp, msg) {
+		new chai.Assertion(val).to.be.a.directory(msg).and.not.deep.equal(exp, msg);
+	};
+};

--- a/lib/assertions/file_equal.js
+++ b/lib/assertions/file_equal.js
@@ -16,7 +16,7 @@ module.exports = function (chai, utils) {
 	Assertion.overwriteMethod('equal', function (_super) {
 		return function assertContent (expected, msg) {
 			if (flag(this, 'fs.isFile')) {
-				var negated = !!flag(this, 'negate');
+				var negated = Boolean(flag(this, 'negate'));
 				var deep = flag(this, 'deep') ? 'deep ' : '';
 
 				var obj = this._obj;

--- a/lib/index.js
+++ b/lib/index.js
@@ -10,6 +10,8 @@ module.exports = function (chai, utils) {
 	require('./assertions/file')(chai, utils);
 	require('./assertions/file_equal')(chai, utils);
 	require('./assertions/directory')(chai, utils);
+	require('./assertions/directory_content')(chai, utils);
+	require('./assertions/directory_equal')(chai, utils);
 	require('./assertions/mode')(chai, utils);
 	require('./assertions/symlink')(chai, utils);
 

--- a/package.json
+++ b/package.json
@@ -41,11 +41,13 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "bit-mask": "0.0.2-alpha"
+    "bit-mask": "0.0.2-alpha",
+    "readdir-enhanced": "^1.4.0"
   },
   "devDependencies": {
     "chai": "^2.3.0",
     "chai-json-schema": "^1.2.0",
+    "del": "^2.2.2",
     "grunt": "^1.0.1",
     "grunt-bump": "^0.8.0",
     "grunt-cli": "^1.2.0",

--- a/test/fixtures/dir-copy/.dotdir/.dotfile
+++ b/test/fixtures/dir-copy/.dotdir/.dotfile
@@ -1,0 +1,1 @@
+Dotfile Tango Victor

--- a/test/fixtures/dir-copy/beta.txt
+++ b/test/fixtures/dir-copy/beta.txt
@@ -1,0 +1,1 @@
+Beta Beer Bar

--- a/test/fixtures/dir/.dotdir/.dotfile
+++ b/test/fixtures/dir/.dotdir/.dotfile
@@ -1,0 +1,1 @@
+Dotfile Tango Victor

--- a/test/init.js
+++ b/test/init.js
@@ -1,5 +1,6 @@
 var mkdirp = require('mkdirp');
 var touch = require('touch');
+var del = require('del');
 var _ = require('underscore');
 
 var chai_fs = require('../lib/index');
@@ -18,15 +19,23 @@ require('./tester')(chai, _);
 
 before(function () {
 	// create some empty dirs (cannot check-in empty dirs to git)
-	mkdirp.sync('./test/fixtures/empty');
 	mkdirp.sync('./test/tmp');
+	mkdirp.sync('./test/fixtures/empty');
+	mkdirp.sync('./test/fixtures/dir/.dotdir/empty');
+	mkdirp.sync('./test/fixtures/dir-copy/.dotdir/empty');
 
+	assert.isDirectory('./test/tmp');
 	assert.isDirectory('./test/fixtures');
 	assert.isDirectory('./test/fixtures/empty');
-	assert.isDirectory('./test/tmp');
+	assert.isDirectory('./test/fixtures/dir/.dotdir/empty');
+	assert.isDirectory('./test/fixtures/dir-copy/.dotdir/empty');
 
-	// Change the times of alpha-copy.txt, so it will be equal, but not DEEP equal to alpha.txt
+	// change the times of alpha-copy.txt, so it will be equal, but not DEEP equal to alpha.txt
 	touch.sync('./test/fixtures/alpha-copy.txt', {time: '2016-01-01T00:00:00Z'});
+
+  // delete files that get created automatically by the OS (they mess-up directory listings)
+  del.sync('test/fixtures/**/.DS_Store', {dot: true});
+  del.sync('test/fixtures/**/Thumbs.db', {dot: true});
 });
 
 describe('chai-fs', function () {

--- a/test/specs/directory_content.js
+++ b/test/specs/directory_content.js
@@ -1,0 +1,275 @@
+describe(require('path').basename(__filename), function () {
+
+	var fs = require('fs');
+	var chai = require('chai');
+	var expect = chai.expect;
+	var assert = chai.assert;
+
+	var styles = {
+		"expect/should": {
+			base: {
+				"basic": function (params) {
+					if (params.contains && params.deep) {
+						expect(params.value).to.be.a.directory().and.contain.deep.contents(params.expected);
+						params.value.should.be.a.directory().and.contain.deep.contents(params.expected);
+						expect(params.value).to.be.a.directory().and.deep.content.contains.members(params.expected);
+					}
+					else if (params.contains) {
+						expect(params.value).to.be.a.directory().and.contain.contents(params.expected);
+						params.value.should.be.a.directory().and.contain.contents(params.expected);
+						params.value.should.be.a.directory().and.content.contains.members(params.expected);
+					}
+					else if (params.deep) {
+						expect(params.value).to.be.a.directory().with.deep.contents(params.expected);
+						params.value.should.be.a.directory().with.deep.contents(params.expected);
+						expect(params.value).to.be.a.directory().with.deep.contents.that.have.members(params.expected);
+					}
+					else {
+						expect(params.value).to.be.a.directory().with.contents(params.expected);
+						params.value.should.be.a.directory().with.contents(params.expected);
+						expect(params.value).to.be.a.directory().with.contents.that.have.members(params.expected);
+					}
+
+					// Test chaining with normal array assertions
+					expect(params.value).to.be.a.directory().and.content.is.an('array');
+					expect(params.value).to.be.a.directory().and.contents.satisfy(function(contents) {
+						return contents.every(function(item) {
+							return typeof item === 'string';
+						});
+					});
+				},
+				"with message": {msg: true, call: function (params) {
+					if (params.contains && params.deep) {
+						expect(params.value).to.be.a.directory(params.msg).and.contain.deep.contents(params.expected, params.msg);
+						params.value.should.be.a.directory(params.msg).and.contain.deep.contents(params.expected, params.msg);
+					}
+					else if (params.contains) {
+						expect(params.value).to.be.a.directory(params.msg).and.contain.contents(params.expected, params.msg);
+						params.value.should.be.a.directory(params.msg).and.contain.contents(params.expected, params.msg);
+					}
+					else if (params.deep) {
+						expect(params.value).to.be.a.directory(params.msg).with.deep.contents(params.expected, params.msg);
+						params.value.should.be.a.directory(params.msg).with.deep.contents(params.expected, params.msg);
+					}
+					else {
+						expect(params.value).to.be.a.directory(params.msg).with.contents(params.expected, params.msg);
+						params.value.should.be.a.directory(params.msg).with.contents(params.expected, params.msg);
+					}
+				}},
+			},
+			negate: {
+				"basic": function (params) {
+					if (params.contains && params.deep) {
+						expect(params.value).to.be.a.directory().and.not.contain.deep.contents(params.expected);
+						params.value.should.be.a.directory().and.not.contain.deep.contents(params.expected);
+					}
+					else if (params.contains) {
+						expect(params.value).to.be.a.directory().and.not.contain.contents(params.expected);
+						params.value.should.be.a.directory().and.not.contain.contents(params.expected);
+					}
+					else if (params.deep) {
+						expect(params.value).to.be.a.directory().and.not.have.deep.contents(params.expected);
+						params.value.should.be.a.directory().and.not.have.deep.contents(params.expected);
+					}
+					else {
+						expect(params.value).to.be.a.directory().and.not.have.contents(params.expected);
+						params.value.should.be.a.directory().and.not.have.contents(params.expected);
+					}
+
+					// Test chaining with normal array assertions
+					params.value.should.be.a.directory().and.contents.is.not.a('string');
+					params.value.should.be.a.directory().and.deep.contents.not.have.lengthOf(999);
+					params.value.should.be.a.directory().and.contents.not.contain('does-not-exist.txt');
+					params.value.should.be.a.directory().and.contents.not.satisfy(function(contents) {
+						return contents.indexOf('does-not-exist.txt') >= 0;
+					});
+				},
+				"with message": {msg: true, call: function (params) {
+					if (params.contains && params.deep) {
+						expect(params.value).to.be.a.directory(params.msg).and.not.contain.deep.contents(params.expected, params.msg);
+						params.value.should.be.a.directory(params.msg).and.not.contain.deep.contents(params.expected, params.msg);
+					}
+					else if (params.contains) {
+						expect(params.value).to.be.a.directory(params.msg).and.not.contain.contents(params.expected, params.msg);
+						params.value.should.be.a.directory(params.msg).and.not.contain.contents(params.expected, params.msg);
+					}
+					else if (params.deep) {
+						expect(params.value).to.be.a.directory(params.msg).and.not.have.deep.contents(params.expected, params.msg);
+						params.value.should.be.a.directory(params.msg).and.not.have.deep.contents(params.expected, params.msg);
+					}
+					else {
+						expect(params.value).to.be.a.directory(params.msg).and.not.have.contents(params.expected, params.msg);
+						params.value.should.be.a.directory(params.msg).and.not.have.contents(params.expected, params.msg);
+					}
+				}}
+			}
+		},
+		assert: {
+			base: {
+				"basic": function (params) {
+					if (params.contains && params.deep) {
+						assert.directoryDeepInclude(params.value, params.expected);
+					}
+					else if (params.contains) {
+						assert.directoryInclude(params.value, params.expected);
+					}
+					else if (params.deep) {
+						assert.directoryDeepContent(params.value, params.expected);
+					}
+					else {
+						assert.directoryContent(params.value, params.expected);
+					}
+				},
+				"with message": {msg: true, call: function (params) {
+					if (params.contains && params.deep) {
+						assert.directoryDeepInclude(params.value, params.expected, params.msg);
+					}
+					else if (params.contains) {
+						assert.directoryInclude(params.value, params.expected, params.msg);
+					}
+					else if (params.deep) {
+						assert.directoryDeepContent(params.value, params.expected, params.msg);
+					}
+					else {
+						assert.directoryContent(params.value, params.expected, params.msg);
+					}
+				}}
+			},
+			negate: {
+				"basic": function (params) {
+					if (params.contains && params.deep) {
+						assert.notDirectoryDeepInclude(params.value, params.expected);
+					}
+					else if (params.contains) {
+						assert.notDirectoryInclude(params.value, params.expected);
+					}
+					else if (params.deep) {
+						assert.notDirectoryDeepContent(params.value, params.expected);
+					}
+					else {
+						assert.notDirectoryContent(params.value, params.expected);
+					}
+				},
+				"with message": {msg: true, call: function (params) {
+					if (params.contains && params.deep) {
+						assert.notDirectoryDeepInclude(params.value, params.expected, params.msg);
+					}
+					else if (params.contains) {
+						assert.notDirectoryInclude(params.value, params.expected, params.msg);
+					}
+					else if (params.deep) {
+						assert.notDirectoryDeepContent(params.value, params.expected, params.msg);
+					}
+					else {
+						assert.notDirectoryContent(params.value, params.expected, params.msg);
+					}
+				}}
+			}
+		}
+	};
+
+	var SHALLOW_CONTENTS = fs.readdirSync('test/fixtures');
+	var DEEP_CONTENTS = SHALLOW_CONTENTS.slice();
+	DEEP_CONTENTS.splice(DEEP_CONTENTS.indexOf('dir'), 0,
+		'dir/beta.txt',
+		'dir/.dotdir',
+		'dir/.dotdir/.dotfile',
+		'dir/.dotdir/empty'
+	);
+	DEEP_CONTENTS.splice(DEEP_CONTENTS.indexOf('dir-copy'), 0,
+		'dir-copy/beta.txt',
+		'dir-copy/.dotdir',
+		'dir-copy/.dotdir/.dotfile',
+		'dir-copy/.dotdir/empty'
+	);
+
+	var test = chai.getStyleTest(styles, {msg: 'My Message', chain: true});
+
+	test.valid({
+		label: 'shallow',
+		value: 'test/fixtures',
+		expected: SHALLOW_CONTENTS,
+		length: SHALLOW_CONTENTS.length,
+		report: "expected '<%= value %>' to not have the same contents as [ Array(<%= length %>) ]"
+	});
+	test.valid({
+		label: 'deep',
+		deep: true,
+		value: 'test/fixtures',
+		expected: DEEP_CONTENTS,
+		length: DEEP_CONTENTS.length,
+		report: "expected '<%= value %>' to not have the same deep contents as [ Array(<%= length %>) ]"
+	});
+	test.valid({
+		label: 'shallow, subset',
+		contains: true,
+		value: 'test/fixtures',
+		expected: ['alpha.txt', 'symlink.txt', 'empty', 'dir'],
+		report: "expected '<%= value %>' to not contain contents [ Array(4) ]"
+	});
+	test.valid({
+		label: 'deep, subset',
+		deep: true,
+		contains: true,
+		value: 'test/fixtures',
+		expected: ['alpha.txt', 'symlink.txt', 'empty', 'dir/.dotdir/.dotfile', 'dir/.dotdir/empty'],
+		report: "expected '<%= value %>' to not contain deep contents [ Array(5) ]"
+	});
+
+	test.invalid({
+		label: 'empty',
+		value: 'test/fixtures',
+		expected: [],
+		report: "expected '<%= value %>' to have the same contents as []"
+	});
+	test.invalid({
+		label: 'shallow',
+		value: 'test/fixtures',
+		expected: ['alpha.json', 'empty'],
+		report: "expected '<%= value %>' to have the same contents as [ 'alpha.json', 'empty' ]"
+	});
+	test.invalid({
+		label: 'deep',
+		deep: true,
+		value: 'test/fixtures',
+		expected: ['empty', 'dir/.dotdir/.dotfile'],
+		report: "expected '<%= value %>' to have the same deep contents as [ 'dir/.dotdir/.dotfile', 'empty' ]"
+	});
+	test.invalid({
+		label: 'shallow, subset',
+		contains: true,
+		value: 'test/fixtures',
+		expected: ['empty/not-empty', 'does-not-exist.txt'],
+		report: "expected '<%= value %>' to contain contents [ Array(2) ]"
+	});
+	test.invalid({
+		label: 'deep, subset',
+		deep: true,
+		contains: true,
+		value: 'test/fixtures',
+		expected: ['dir/.dotdir/empty/not-empty', 'does-not-exist.txt'],
+		report: "expected '<%= value %>' to contain deep contents [ Array(2) ]"
+	});
+
+	test.error({
+		label: 'not a directory',
+		value: 'test/fixtures/alpha.json',
+		report: "expected '<%= value %>' to be a directory"
+	});
+	test.error({
+		label: 'non-existing path',
+		value: 'test/fixtures/non-existing',
+		report: "value: expected '<%= value %>' to exist"
+	});
+	test.error({
+		label: 'bad value type',
+		value: 123,
+		report: "value: expected <%= value %> to be a string"
+	});
+	test.error({
+		label: 'bad expected type',
+		value: 'test/fixtures',
+		expected: 123,
+		report: "expected-value: expected <%= expected %> to be an array"
+	});
+});

--- a/test/specs/directory_equal.js
+++ b/test/specs/directory_equal.js
@@ -1,0 +1,201 @@
+describe(require('path').basename(__filename), function () {
+
+	var chai = require('chai');
+	var expect = chai.expect;
+	var assert = chai.assert;
+
+	var styles = {
+		"expect/should": {
+			base: {
+				"basic": function (params) {
+					if (params.deep) {
+						expect(params.value).to.be.a.directory().and.deep.equal(params.expected);
+						params.value.should.be.a.directory().and.deep.equal(params.expected);
+					}
+					else {
+						expect(params.value).to.be.a.directory().and.equal(params.expected);
+						params.value.should.be.a.directory().and.equal(params.expected);
+					}
+				},
+				"with message": {msg: true, call: function (params) {
+					if (params.deep) {
+						expect(params.value).to.be.a.directory(params.msg).and.deep.equal(params.expected, params.msg);
+						params.value.should.be.a.directory(params.msg).and.deep.equal(params.expected, params.msg);
+					}
+					else {
+						expect(params.value).to.be.a.directory(params.msg).and.equal(params.expected, params.msg);
+						params.value.should.be.a.directory(params.msg).and.equal(params.expected, params.msg);
+					}
+				}}
+			},
+			negate: {
+				"basic": function (params) {
+					if (params.deep) {
+						expect(params.value).to.be.a.directory().and.not.deep.equal(params.expected);
+						params.value.should.be.a.directory().and.not.deep.equal(params.expected);
+					}
+					else {
+						expect(params.value).to.be.a.directory().and.not.equal(params.expected);
+						params.value.should.be.a.directory().and.not.equal(params.expected);
+					}
+				},
+				"with message": {msg: true, call: function (params) {
+					if (params.deep) {
+						expect(params.value).to.be.a.directory(params.msg).and.not.deep.equal(params.expected, params.msg);
+						params.value.should.be.a.directory(params.msg).and.not.deep.equal(params.expected, params.msg);
+					}
+					else {
+						expect(params.value).to.be.a.directory(params.msg).and.not.equal(params.expected, params.msg);
+						params.value.should.be.a.directory(params.msg).and.not.equal(params.expected, params.msg);
+					}
+				}}
+			}
+		},
+		assert: {
+			base: {
+				"basic": function (params) {
+					if (params.deep) {
+						assert.directoryDeepEqual(params.value, params.expected);
+					}
+					else {
+						assert.directoryEqual(params.value, params.expected);
+					}
+				},
+				"with message": {msg: true, call: function (params) {
+					if (params.deep) {
+						assert.directoryDeepEqual(params.value, params.expected, params.msg);
+					}
+					else {
+						assert.directoryEqual(params.value, params.expected, params.msg);
+					}
+				}}
+			},
+			negate: {
+				"basic": function (params) {
+					if (params.deep) {
+						assert.notDirectoryDeepEqual(params.value, params.expected);
+					}
+					else {
+						assert.notDirectoryEqual(params.value, params.expected);
+					}
+				},
+				"with message": {msg: true, call: function (params) {
+					if (params.deep) {
+						assert.notDirectoryDeepEqual(params.value, params.expected, params.msg);
+					}
+					else {
+						assert.notDirectoryEqual(params.value, params.expected, params.msg);
+					}
+				}}
+			}
+		}
+	};
+
+	var test = chai.getStyleTest(styles, {msg: 'My Message'});
+
+	test.valid({
+		label: 'same directory',
+		value: 'test/fixtures',
+		expected: 'test/fixtures',
+		report: "expected '<%= value %>' not to equal '<%= expected %>'"
+	});
+	test.valid({
+		label: 'same directory - deep',
+		deep: true,
+		value: 'test/fixtures',
+		expected: 'test/fixtures',
+		report: "expected '<%= value %>' not to deep equal '<%= expected %>'"
+	});
+
+	test.invalid({
+		label: 'different directories',
+		value: 'test/fixtures',
+		expected: 'test/fixtures/dir',
+		report: "expected '<%= value %>' to equal '<%= expected %>'"
+	});
+	test.invalid({
+		label: 'different directories - deep',
+		deep: true,
+		value: 'test/fixtures',
+		expected: 'test/fixtures/dir',
+		report: "expected '<%= value %>' to deep equal '<%= expected %>'"
+	});
+
+	test.valid({
+		label: 'different directories, same contents',
+		value: 'test/fixtures/dir',
+		expected: 'test/fixtures/dir-copy',
+		report: "expected '<%= value %>' not to equal '<%= expected %>'"
+	});
+	test.valid({
+		label: 'different directories, same contents - deep',
+		deep: true,
+		value: 'test/fixtures/dir',
+		expected: 'test/fixtures/dir-copy',
+		report: "expected '<%= value %>' not to deep equal '<%= expected %>'"
+	});
+
+	test.valid({
+		label: 'empty directory',
+		value: 'test/fixtures/empty',
+		expected: 'test/fixtures/dir/.dotdir/empty',
+		report: "expected '<%= value %>' not to equal '<%= expected %>'"
+	});
+	test.valid({
+		label: 'empty directory - deep',
+		deep: true,
+		value: 'test/fixtures/empty',
+		expected: 'test/fixtures/dir/.dotdir/empty',
+		report: "expected '<%= value %>' not to deep equal '<%= expected %>'"
+	});
+
+	test.error({
+		label: 'not a directory',
+		value: 'test/fixtures/alpha.txt',
+		report: "expected '<%= value %>' to be a directory"
+	});
+	test.error({
+		label: 'not a directory - deep',
+		deep: true,
+		value: 'test/fixtures/alpha.txt',
+		report: "expected '<%= value %>' to be a directory"
+	});
+
+	test.error({
+		label: 'non-existing path',
+		value: 'test/fixtures/non-existing',
+		report: "value: expected '<%= value %>' to exist"
+	});
+	test.error({
+		label: 'non-existing path - deep',
+		deep: true,
+		value: 'test/fixtures/non-existing',
+		report: "value: expected '<%= value %>' to exist"
+	});
+
+	test.error({
+		label: 'bad expected type',
+		value: 'test/fixtures',
+		expected: 123,
+		report: "expected-value: expected <%= expected %> to be a string"
+	});
+	test.error({
+		label: 'bad expected type - deep',
+		deep: true,
+		value: 'test/fixtures',
+		expected: 123,
+		report: "expected-value: expected <%= expected %> to be a string"
+	});
+
+	test.error({
+		label: 'bad value type',
+		value: 123,
+		report: "value: expected <%= value %> to be a string"
+	});
+	test.error({
+		label: 'bad value type - deep',
+		deep: true,
+		value: 123,
+		report: "value: expected <%= value %> to be a string"
+	});
+});

--- a/test/specs/directory_files.js
+++ b/test/specs/directory_files.js
@@ -1,0 +1,274 @@
+describe(require('path').basename(__filename), function () {
+
+	var fs = require('fs');
+	var chai = require('chai');
+	var expect = chai.expect;
+	var assert = chai.assert;
+
+	var styles = {
+		"expect/should": {
+			base: {
+				"basic": function (params) {
+					if (params.contains && params.deep) {
+						expect(params.value).to.be.a.directory().and.contain.deep.files(params.expected);
+						params.value.should.be.a.directory().and.contain.deep.files(params.expected);
+						expect(params.value).to.be.a.directory().and.deep.content.contains.members(params.expected);
+					}
+					else if (params.contains) {
+						expect(params.value).to.be.a.directory().and.contain.files(params.expected);
+						params.value.should.be.a.directory().and.contain.files(params.expected);
+						params.value.should.be.a.directory().and.content.contains.members(params.expected);
+					}
+					else if (params.deep) {
+						expect(params.value).to.be.a.directory().with.deep.files(params.expected);
+						params.value.should.be.a.directory().with.deep.files(params.expected);
+						expect(params.value).to.be.a.directory().with.deep.files.that.have.members(params.expected);
+					}
+					else {
+						expect(params.value).to.be.a.directory().with.files(params.expected);
+						params.value.should.be.a.directory().with.files(params.expected);
+						expect(params.value).to.be.a.directory().with.files.that.have.members(params.expected);
+					}
+
+					// Test chaining with normal array assertions
+					expect(params.value).to.be.a.directory().and.content.is.an('array');
+					expect(params.value).to.be.a.directory().and.files.satisfy(function(files) {
+						return files.every(function(item) {
+							return typeof item === 'string';
+						});
+					});
+				},
+				"with message": {msg: true, call: function (params) {
+					if (params.contains && params.deep) {
+						expect(params.value).to.be.a.directory(params.msg).and.contain.deep.files(params.expected, params.msg);
+						params.value.should.be.a.directory(params.msg).and.contain.deep.files(params.expected, params.msg);
+					}
+					else if (params.contains) {
+						expect(params.value).to.be.a.directory(params.msg).and.contain.files(params.expected, params.msg);
+						params.value.should.be.a.directory(params.msg).and.contain.files(params.expected, params.msg);
+					}
+					else if (params.deep) {
+						expect(params.value).to.be.a.directory(params.msg).with.deep.files(params.expected, params.msg);
+						params.value.should.be.a.directory(params.msg).with.deep.files(params.expected, params.msg);
+					}
+					else {
+						expect(params.value).to.be.a.directory(params.msg).with.files(params.expected, params.msg);
+						params.value.should.be.a.directory(params.msg).with.files(params.expected, params.msg);
+					}
+				}},
+			},
+			negate: {
+				"basic": function (params) {
+					if (params.contains && params.deep) {
+						expect(params.value).to.be.a.directory().and.not.contain.deep.files(params.expected);
+						params.value.should.be.a.directory().and.not.contain.deep.files(params.expected);
+					}
+					else if (params.contains) {
+						expect(params.value).to.be.a.directory().and.not.contain.files(params.expected);
+						params.value.should.be.a.directory().and.not.contain.files(params.expected);
+					}
+					else if (params.deep) {
+						expect(params.value).to.be.a.directory().and.not.have.deep.files(params.expected);
+						params.value.should.be.a.directory().and.not.have.deep.files(params.expected);
+					}
+					else {
+						expect(params.value).to.be.a.directory().and.not.have.files(params.expected);
+						params.value.should.be.a.directory().and.not.have.files(params.expected);
+					}
+
+					// Test chaining with normal array assertions
+					params.value.should.be.a.directory().and.files.is.not.a('string');
+					params.value.should.be.a.directory().and.deep.files.not.have.lengthOf(999);
+					params.value.should.be.a.directory().and.files.not.contain('does-not-exist.txt');
+					params.value.should.be.a.directory().and.files.not.satisfy(function(files) {
+						return files.indexOf('does-not-exist.txt') >= 0;
+					});
+				},
+				"with message": {msg: true, call: function (params) {
+					if (params.contains && params.deep) {
+						expect(params.value).to.be.a.directory(params.msg).and.not.contain.deep.files(params.expected, params.msg);
+						params.value.should.be.a.directory(params.msg).and.not.contain.deep.files(params.expected, params.msg);
+					}
+					else if (params.contains) {
+						expect(params.value).to.be.a.directory(params.msg).and.not.contain.files(params.expected, params.msg);
+						params.value.should.be.a.directory(params.msg).and.not.contain.files(params.expected, params.msg);
+					}
+					else if (params.deep) {
+						expect(params.value).to.be.a.directory(params.msg).and.not.have.deep.files(params.expected, params.msg);
+						params.value.should.be.a.directory(params.msg).and.not.have.deep.files(params.expected, params.msg);
+					}
+					else {
+						expect(params.value).to.be.a.directory(params.msg).and.not.have.files(params.expected, params.msg);
+						params.value.should.be.a.directory(params.msg).and.not.have.files(params.expected, params.msg);
+					}
+				}}
+			}
+		},
+		assert: {
+			base: {
+				"basic": function (params) {
+					if (params.contains && params.deep) {
+						assert.directoryDeepIncludeFiles(params.value, params.expected);
+					}
+					else if (params.contains) {
+						assert.directoryIncludeFiles(params.value, params.expected);
+					}
+					else if (params.deep) {
+						assert.directoryDeepFiles(params.value, params.expected);
+					}
+					else {
+						assert.directoryFiles(params.value, params.expected);
+					}
+				},
+				"with message": {msg: true, call: function (params) {
+					if (params.contains && params.deep) {
+						assert.directoryDeepIncludeFiles(params.value, params.expected, params.msg);
+					}
+					else if (params.contains) {
+						assert.directoryIncludeFiles(params.value, params.expected, params.msg);
+					}
+					else if (params.deep) {
+						assert.directoryDeepFiles(params.value, params.expected, params.msg);
+					}
+					else {
+						assert.directoryFiles(params.value, params.expected, params.msg);
+					}
+				}}
+			},
+			negate: {
+				"basic": function (params) {
+					if (params.contains && params.deep) {
+						assert.notDirectoryDeepIncludeFiles(params.value, params.expected);
+					}
+					else if (params.contains) {
+						assert.notDirectoryIncludeFiles(params.value, params.expected);
+					}
+					else if (params.deep) {
+						assert.notDirectoryDeepFiles(params.value, params.expected);
+					}
+					else {
+						assert.notDirectoryFiles(params.value, params.expected);
+					}
+				},
+				"with message": {msg: true, call: function (params) {
+					if (params.contains && params.deep) {
+						assert.notDirectoryDeepIncludeFiles(params.value, params.expected, params.msg);
+					}
+					else if (params.contains) {
+						assert.notDirectoryIncludeFiles(params.value, params.expected, params.msg);
+					}
+					else if (params.deep) {
+						assert.notDirectoryDeepFiles(params.value, params.expected, params.msg);
+					}
+					else {
+						assert.notDirectoryFiles(params.value, params.expected, params.msg);
+					}
+				}}
+			}
+		}
+	};
+
+	var SHALLOW_FILES = fs.readdirSync('test/fixtures');
+	SHALLOW_FILES.splice(SHALLOW_FILES.indexOf('dir'), 1);
+	SHALLOW_FILES.splice(SHALLOW_FILES.indexOf('dir-copy'), 1);
+	SHALLOW_FILES.splice(SHALLOW_FILES.indexOf('empty'), 1);
+	SHALLOW_FILES.splice(SHALLOW_FILES.indexOf('broken-symlink.txt'), 1);
+
+	var DEEP_FILES = SHALLOW_FILES.slice();
+	DEEP_FILES.push(
+		'dir/beta.txt',
+		'dir/.dotdir/.dotfile',
+		'dir-copy/beta.txt',
+		'dir-copy/.dotdir/.dotfile'
+	);
+
+	var test = chai.getStyleTest(styles, {msg: 'My Message', chain: true});
+
+	test.valid({
+		label: 'shallow',
+		value: 'test/fixtures',
+		expected: SHALLOW_FILES,
+		length: SHALLOW_FILES.length,
+		report: "expected '<%= value %>' to not have the same files as [ Array(<%= length %>) ]"
+	});
+	test.valid({
+		label: 'deep',
+		deep: true,
+		value: 'test/fixtures',
+		expected: DEEP_FILES,
+		length: DEEP_FILES.length,
+		report: "expected '<%= value %>' to not have the same deep files as [ Array(<%= length %>) ]"
+	});
+	test.valid({
+		label: 'shallow, subset',
+		contains: true,
+		value: 'test/fixtures',
+		expected: ['alpha.txt', 'symlink.txt', 'tango.json', 'empty.txt'],
+		report: "expected '<%= value %>' to not contain files [ Array(4) ]"
+	});
+	test.valid({
+		label: 'deep, subset',
+		deep: true,
+		contains: true,
+		value: 'test/fixtures',
+		expected: ['alpha.txt', 'symlink.txt', 'dir/.dotdir/.dotfile', 'dir/beta.txt'],
+		report: "expected '<%= value %>' to not contain deep files [ Array(4) ]"
+	});
+
+	test.invalid({
+		label: 'empty',
+		value: 'test/fixtures',
+		expected: [],
+		report: "expected '<%= value %>' to have the same files as []"
+	});
+	test.invalid({
+		label: 'shallow',
+		value: 'test/fixtures',
+		expected: ['alpha.json', 'symlink.txt'],
+		report: "expected '<%= value %>' to have the same files as [ 'alpha.json', 'symlink.txt' ]"
+	});
+	test.invalid({
+		label: 'deep',
+		deep: true,
+		value: 'test/fixtures',
+		expected: ['empty.txt', 'dir/.dotdir/.dotfile'],
+		report: "expected '<%= value %>' to have the same deep files as [ 'dir/.dotdir/.dotfile', 'empty.txt' ]"
+	});
+	test.invalid({
+		label: 'shallow, subset',
+		contains: true,
+		value: 'test/fixtures',
+		expected: ['does-not-exist.txt'],
+		report: "expected '<%= value %>' to contain files [ 'does-not-exist.txt' ]"
+	});
+	test.invalid({
+		label: 'deep, subset',
+		deep: true,
+		contains: true,
+		value: 'test/fixtures',
+		expected: ['dir/.dotdir/does-not-exist', 'does-not-exist.txt'],
+		report: "expected '<%= value %>' to contain deep files [ Array(2) ]"
+	});
+
+	test.error({
+		label: 'not a directory',
+		value: 'test/fixtures/alpha.json',
+		report: "expected '<%= value %>' to be a directory"
+	});
+	test.error({
+		label: 'non-existing path',
+		value: 'test/fixtures/non-existing',
+		report: "value: expected '<%= value %>' to exist"
+	});
+	test.error({
+		label: 'bad value type',
+		value: 123,
+		report: "value: expected <%= value %> to be a string"
+	});
+	test.error({
+		label: 'bad expected type',
+		value: 'test/fixtures',
+		expected: 123,
+		report: "expected-value: expected <%= expected %> to be an array"
+	});
+});

--- a/test/specs/directory_subdirs.js
+++ b/test/specs/directory_subdirs.js
@@ -1,0 +1,269 @@
+describe(require('path').basename(__filename), function () {
+
+	var chai = require('chai');
+	var expect = chai.expect;
+	var assert = chai.assert;
+
+	var styles = {
+		"expect/should": {
+			base: {
+				"basic": function (params) {
+					if (params.contains && params.deep) {
+						expect(params.value).to.be.a.directory().and.contain.deep.subDirs(params.expected);
+						params.value.should.be.a.directory().and.contain.deep.subDirs(params.expected);
+						expect(params.value).to.be.a.directory().and.deep.content.contains.members(params.expected);
+					}
+					else if (params.contains) {
+						expect(params.value).to.be.a.directory().and.contain.subDirs(params.expected);
+						params.value.should.be.a.directory().and.contain.subDirs(params.expected);
+						params.value.should.be.a.directory().and.content.contains.members(params.expected);
+					}
+					else if (params.deep) {
+						expect(params.value).to.be.a.directory().with.deep.subDirs(params.expected);
+						params.value.should.be.a.directory().with.deep.subDirs(params.expected);
+						expect(params.value).to.be.a.directory().with.deep.subDirs.that.have.members(params.expected);
+					}
+					else {
+						expect(params.value).to.be.a.directory().with.subDirs(params.expected);
+						params.value.should.be.a.directory().with.subDirs(params.expected);
+						expect(params.value).to.be.a.directory().with.subDirs.that.have.members(params.expected);
+					}
+
+					// Test chaining with normal array assertions
+					expect(params.value).to.be.a.directory().and.content.is.an('array');
+					expect(params.value).to.be.a.directory().and.subDirs.satisfy(function(subdirs) {
+						return subdirs.every(function(item) {
+							return typeof item === 'string';
+						});
+					});
+				},
+				"with message": {msg: true, call: function (params) {
+					if (params.contains && params.deep) {
+						expect(params.value).to.be.a.directory(params.msg).and.contain.deep.subDirs(params.expected, params.msg);
+						params.value.should.be.a.directory(params.msg).and.contain.deep.subDirs(params.expected, params.msg);
+					}
+					else if (params.contains) {
+						expect(params.value).to.be.a.directory(params.msg).and.contain.subDirs(params.expected, params.msg);
+						params.value.should.be.a.directory(params.msg).and.contain.subDirs(params.expected, params.msg);
+					}
+					else if (params.deep) {
+						expect(params.value).to.be.a.directory(params.msg).with.deep.subDirs(params.expected, params.msg);
+						params.value.should.be.a.directory(params.msg).with.deep.subDirs(params.expected, params.msg);
+					}
+					else {
+						expect(params.value).to.be.a.directory(params.msg).with.subDirs(params.expected, params.msg);
+						params.value.should.be.a.directory(params.msg).with.subDirs(params.expected, params.msg);
+					}
+				}},
+			},
+			negate: {
+				"basic": function (params) {
+					if (params.contains && params.deep) {
+						expect(params.value).to.be.a.directory().and.not.contain.deep.subDirs(params.expected);
+						params.value.should.be.a.directory().and.not.contain.deep.subDirs(params.expected);
+					}
+					else if (params.contains) {
+						expect(params.value).to.be.a.directory().and.not.contain.subDirs(params.expected);
+						params.value.should.be.a.directory().and.not.contain.subDirs(params.expected);
+					}
+					else if (params.deep) {
+						expect(params.value).to.be.a.directory().and.not.have.deep.subDirs(params.expected);
+						params.value.should.be.a.directory().and.not.have.deep.subDirs(params.expected);
+					}
+					else {
+						expect(params.value).to.be.a.directory().and.not.have.subDirs(params.expected);
+						params.value.should.be.a.directory().and.not.have.subDirs(params.expected);
+					}
+
+					// Test chaining with normal array assertions
+					params.value.should.be.a.directory().and.subDirs.is.not.a('string');
+					params.value.should.be.a.directory().and.deep.subDirs.not.have.lengthOf(999);
+					params.value.should.be.a.directory().and.subDirs.not.contain('does-not-exist.txt');
+					params.value.should.be.a.directory().and.subDirs.not.satisfy(function(subdirs) {
+						return subdirs.indexOf('does-not-exist.txt') >= 0;
+					});
+				},
+				"with message": {msg: true, call: function (params) {
+					if (params.contains && params.deep) {
+						expect(params.value).to.be.a.directory(params.msg).and.not.contain.deep.subDirs(params.expected, params.msg);
+						params.value.should.be.a.directory(params.msg).and.not.contain.deep.subDirs(params.expected, params.msg);
+					}
+					else if (params.contains) {
+						expect(params.value).to.be.a.directory(params.msg).and.not.contain.subDirs(params.expected, params.msg);
+						params.value.should.be.a.directory(params.msg).and.not.contain.subDirs(params.expected, params.msg);
+					}
+					else if (params.deep) {
+						expect(params.value).to.be.a.directory(params.msg).and.not.have.deep.subDirs(params.expected, params.msg);
+						params.value.should.be.a.directory(params.msg).and.not.have.deep.subDirs(params.expected, params.msg);
+					}
+					else {
+						expect(params.value).to.be.a.directory(params.msg).and.not.have.subDirs(params.expected, params.msg);
+						params.value.should.be.a.directory(params.msg).and.not.have.subDirs(params.expected, params.msg);
+					}
+				}}
+			}
+		},
+		assert: {
+			base: {
+				"basic": function (params) {
+					if (params.contains && params.deep) {
+						assert.directoryDeepIncludeSubDirs(params.value, params.expected);
+					}
+					else if (params.contains) {
+						assert.directoryIncludeSubDirs(params.value, params.expected);
+					}
+					else if (params.deep) {
+						assert.directoryDeepSubDirs(params.value, params.expected);
+					}
+					else {
+						assert.directorySubDirs(params.value, params.expected);
+					}
+				},
+				"with message": {msg: true, call: function (params) {
+					if (params.contains && params.deep) {
+						assert.directoryDeepIncludeSubDirs(params.value, params.expected, params.msg);
+					}
+					else if (params.contains) {
+						assert.directoryIncludeSubDirs(params.value, params.expected, params.msg);
+					}
+					else if (params.deep) {
+						assert.directoryDeepSubDirs(params.value, params.expected, params.msg);
+					}
+					else {
+						assert.directorySubDirs(params.value, params.expected, params.msg);
+					}
+				}}
+			},
+			negate: {
+				"basic": function (params) {
+					if (params.contains && params.deep) {
+						assert.notDirectoryDeepIncludeSubDirs(params.value, params.expected);
+					}
+					else if (params.contains) {
+						assert.notDirectoryIncludeSubDirs(params.value, params.expected);
+					}
+					else if (params.deep) {
+						assert.notDirectoryDeepSubDirs(params.value, params.expected);
+					}
+					else {
+						assert.notDirectorySubDirs(params.value, params.expected);
+					}
+				},
+				"with message": {msg: true, call: function (params) {
+					if (params.contains && params.deep) {
+						assert.notDirectoryDeepIncludeSubDirs(params.value, params.expected, params.msg);
+					}
+					else if (params.contains) {
+						assert.notDirectoryIncludeSubDirs(params.value, params.expected, params.msg);
+					}
+					else if (params.deep) {
+						assert.notDirectoryDeepSubDirs(params.value, params.expected, params.msg);
+					}
+					else {
+						assert.notDirectorySubDirs(params.value, params.expected, params.msg);
+					}
+				}}
+			}
+		}
+	};
+
+	var SHALLOW_SUBDIRS = ['empty', 'dir', 'dir-copy'];
+	var DEEP_SUBDIRS = [
+		'empty',
+		'dir',
+		'dir/.dotdir',
+		'dir/.dotdir/empty',
+		'dir-copy',
+		'dir-copy/.dotdir',
+		'dir-copy/.dotdir/empty'
+	];
+
+	var test = chai.getStyleTest(styles, {msg: 'My Message', chain: true});
+
+	test.valid({
+		label: 'shallow',
+		value: 'test/fixtures',
+		expected: SHALLOW_SUBDIRS,
+		report: "expected '<%= value %>' to not have the same sub-directories as [ 'dir', 'dir-copy', 'empty' ]"
+	});
+	test.valid({
+		label: 'deep',
+		deep: true,
+		value: 'test/fixtures',
+		expected: DEEP_SUBDIRS,
+		length: DEEP_SUBDIRS.length,
+		report: "expected '<%= value %>' to not have the same deep sub-directories as [ Array(<%= length %>) ]"
+	});
+	test.valid({
+		label: 'shallow, subset',
+		contains: true,
+		value: 'test/fixtures',
+		expected: ['empty'],
+		report: "expected '<%= value %>' to not contain sub-directories [ 'empty' ]"
+	});
+	test.valid({
+		label: 'deep, subset',
+		deep: true,
+		contains: true,
+		value: 'test/fixtures',
+		expected: ['dir/.dotdir', 'empty'],
+		report: "expected '<%= value %>' to not contain deep sub-directories [ 'dir/.dotdir', 'empty' ]"
+	});
+
+	test.invalid({
+		label: 'empty',
+		value: 'test/fixtures',
+		expected: [],
+		report: "expected '<%= value %>' to have the same sub-directories as []"
+	});
+	test.invalid({
+		label: 'shallow',
+		value: 'test/fixtures',
+		expected: ['dir'],
+		report: "expected '<%= value %>' to have the same sub-directories as [ 'dir' ]"
+	});
+	test.invalid({
+		label: 'deep',
+		deep: true,
+		value: 'test/fixtures',
+		expected: ['empty', 'dir/.dotdir'],
+		report: "expected '<%= value %>' to have the same deep sub-directories as [ 'dir/.dotdir', 'empty' ]"
+	});
+	test.invalid({
+		label: 'shallow, subset',
+		contains: true,
+		value: 'test/fixtures',
+		expected: ['empty/not-empty'],
+		report: "expected '<%= value %>' to contain sub-directories [ 'empty/not-empty' ]"
+	});
+	test.invalid({
+		label: 'deep, subset',
+		deep: true,
+		contains: true,
+		value: 'test/fixtures',
+		expected: ['dir/.dotdir/empty/not-empty', 'dir'],
+		report: "expected '<%= value %>' to contain deep sub-directories [ Array(2) ]"
+	});
+
+	test.error({
+		label: 'not a directory',
+		value: 'test/fixtures/alpha.json',
+		report: "expected '<%= value %>' to be a directory"
+	});
+	test.error({
+		label: 'non-existing path',
+		value: 'test/fixtures/non-existing',
+		report: "value: expected '<%= value %>' to exist"
+	});
+	test.error({
+		label: 'bad value type',
+		value: 123,
+		report: "value: expected <%= value %> to be a string"
+	});
+	test.error({
+		label: 'bad expected type',
+		value: 'test/fixtures',
+		expected: 123,
+		report: "expected-value: expected <%= expected %> to be an array"
+	});
+});


### PR DESCRIPTION
This PR adds several new assertions for comparing the contents of a directory.  There are three types of new assertions:

**1. Compare contents to an array**<br>
These assertions let you test for expected files, sub-directories, or all contents.

```javascript
expect(path).to.be.a.directory().with.files(['file1.txt', 'file2.txt']);
expect(path).to.be.a.directory().with.subDirs(['subdir1', 'subdir2']);
expect(path).to.be.a.directory().with.contents(['file.txt', 'subdir']);

expect(path).to.be.a.directory().and.include.files(['file1.txt', 'file2.txt']);

expect(path).to.be.a.directory().with.deep.contents([
  'file1.txt', 
  'subdir1',
  'subdir1/file2.txt',
  'subdir1/subdir2',
  'subdir1/subdir2/subdir3',
]);
```

**2. Compare two directories for equality**<br>
These assertions let you assert that two directories contain the same contents.

```javascript
expect(path).to.be.a.directory().and.equal(otherPath);

expect(path).to.be.a.directory().and.deep.equal(otherPath);

expect(path).to.be.a.directory().and.not.equal(otherPath);
```

**3. Chain contents with other assertions**<br>
You can chain `.contents`, `.files`, and `.subDirs` with any Chai.js assertion that can operate on an array, including `.lengthOf()`, `.satisfy()`, `.members()`, etc.

```javascript
expect(path).to.be.a.directory().and.content.is.an('array');

expect(path).to.be.a.directory().and.files.have.lengthOf(5);

path.should.be.a.directory().with.subDirs.that.include.members(['subDir1', 'subDir2']);

path.should.be.a.directory().with.files.that.satisfy(function(files) {
  return files.every(function(file) {
    return file.substr(-4) === '.txt';
  });
})
```

-------------------------------------------------------------

Also, as of this commit...  🎉 there are now **999 tests** for `chai-fs` 🎉