### PR TITLE
updated devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,8 +44,8 @@
     "bit-mask": "0.0.2-alpha"
   },
   "devDependencies": {
-    "chai": "^2.3.0",
-    "chai-json-schema": "^1.2.0",
+    "chai": "^3.5.0",
+    "chai-json-schema": "^1.3.0",
     "grunt": "^1.0.1",
     "grunt-bump": "^0.8.0",
     "grunt-cli": "^1.2.0",
@@ -54,6 +54,7 @@
     "grunt-mocha-test": "^0.12.7",
     "jshint-path-reporter": "~0.1",
     "mkdirp": "^0.5.0",
+    "mocha": "^3.0.2",
     "mocha-unfunk-reporter": "^0.4.0",
     "touch": "^1.0.0",
     "underscore": "^1.8.3"


### PR DESCRIPTION
We've been unable to update our devDependency on `chai` due to an outdated peerDependency in `chai-json-schema`, but [that problem has been fixed](https://github.com/chaijs/chai-json-schema/commit/94e4e37b66de2762792f25cfebc6f6051a5bb9e1).  This PR updates `chai` and `chai-json-schema` to their latest versions.

I also added `mocha` as an explicit devDependency.  We've been relying on mocha being installed as a peerDependency of `grunt-mocha-test`, but as of NPM v3, peerDependencies no longer get installed automatically.