### PR TITLE
Fixes Issue #23

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,7 +342,6 @@ Assert that _both_ paths exist, are files, contain the same content, and have th
  * creation time (`stats.birthtime`)
  * last-modified time (`stats.mtime`)
  * last-changed time (`stats.ctime`)
- * last-access time (`stats.atime`)
 
 
 	expect(path).to.be.a.file(?msg).and.deep.equal(otherPath, ?msg);
@@ -356,6 +355,7 @@ Assert that _both_ paths exist, are files, contain the same content, and have th
 
 * Reads both files as utf8 text (could update to support base64, binary Buffer etc).
 * To negate this using `expect/should` you chain the `.not`-negation ***after*** the regular `file()`.
+* last-access time (`stats.atime`) is _not_ included in the comparison, since just reading this value (via `fs.stat()`) causes it to change on some operating systems, which could result in unstable tests
 
 ### file().with.json
 

--- a/lib/assertions/file_equal.js
+++ b/lib/assertions/file_equal.js
@@ -46,7 +46,6 @@ module.exports = function (chai, utils) {
 					var comparisons = [
 						{prop: 'uid', name: 'owner'},
 						{prop: 'gid', name: 'group id'},
-						{prop: 'atime', name: 'last-access time'},
 						{prop: 'mtime', name: 'last-modified time'},
 						{prop: 'ctime', name: 'last-changed time'},
 						{prop: 'birthtime', name: 'creation time'},

--- a/test/init.js
+++ b/test/init.js
@@ -17,25 +17,25 @@ var assert = chai.assert;
 // import assertion multi tester
 require('./tester')(chai, _);
 
-before(function () {
-	// create some empty dirs (cannot check-in empty dirs to git)
-	mkdirp.sync('./test/tmp');
-	mkdirp.sync('./test/fixtures/empty');
-	mkdirp.sync('./test/fixtures/dir/.dotdir/empty');
-	mkdirp.sync('./test/fixtures/dir-copy/.dotdir/empty');
+// create some empty dirs (cannot check-in empty dirs to git)
+mkdirp.sync('./test/tmp');
+mkdirp.sync('./test/fixtures/empty');
+mkdirp.sync('./test/fixtures/dir/.dotdir/empty');
+mkdirp.sync('./test/fixtures/dir-copy/.dotdir/empty');
 
+// change the times of alpha-copy.txt, so it will be equal, but not DEEP equal to alpha.txt
+touch.sync('./test/fixtures/alpha-copy.txt', {time: '2016-01-01T00:00:00Z'});
+
+// delete files that get created automatically by the OS (they mess-up directory listings)
+del.sync('test/fixtures/**/.DS_Store', {dot: true});
+del.sync('test/fixtures/**/Thumbs.db', {dot: true});
+
+describe('initialized', function () {
 	assert.isDirectory('./test/tmp');
 	assert.isDirectory('./test/fixtures');
 	assert.isDirectory('./test/fixtures/empty');
 	assert.isDirectory('./test/fixtures/dir/.dotdir/empty');
 	assert.isDirectory('./test/fixtures/dir-copy/.dotdir/empty');
-
-	// change the times of alpha-copy.txt, so it will be equal, but not DEEP equal to alpha.txt
-	touch.sync('./test/fixtures/alpha-copy.txt', {time: '2016-01-01T00:00:00Z'});
-
-  // delete files that get created automatically by the OS (they mess-up directory listings)
-  del.sync('test/fixtures/**/.DS_Store', {dot: true});
-  del.sync('test/fixtures/**/Thumbs.db', {dot: true});
 });
 
 describe('chai-fs', function () {


### PR DESCRIPTION
Fixes an issue where tests failed the first time they were run, but passed on subsequent times (see https://github.com/chaijs/chai-fs/issues/23#issuecomment-252935632).

The code that sets-up the `test/fixtures` directory needs to run _immediately_, rather than inside a `before()` callback, since [some tests](https://github.com/chaijs/chai-fs/blob/9f20e90798433d9fe1e3238e781d17b9d4878957/test/specs/directory_content.js#L171-L194) rely on those files and directories existing at the time that the tests are defined.
