### PR TITLE
Release 2.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "chai-fs",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chai-fs",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Chai assertions for Node.js filesystem",
   "author": {
     "name": "Bart van der Schoor",


### PR DESCRIPTION
Following #40, this PR bumps version to 2.0.0.
There is also a `v2.0.0` tag 